### PR TITLE
Address keyword argument deprecation warnings

### DIFF
--- a/lib/capybara_accessible_selectors/locate_by_fieldset.rb
+++ b/lib/capybara_accessible_selectors/locate_by_fieldset.rb
@@ -7,7 +7,7 @@
     block = @expressions[:xpath]
     @expressions[:xpath] = lambda do |locator, *args, **options|
       *fieldsets, locator = locator if locator.is_a? Array
-      xpath = instance_exec(locator, *args, options, &block)
+      xpath = instance_exec(locator, *args, **options, &block)
       xpath = CapybaraAccessibleSelectors::Helpers.within_fieldset(xpath, fieldsets) if fieldsets&.any?
       xpath
     end

--- a/lib/capybara_accessible_selectors/rspec/matchers.rb
+++ b/lib/capybara_accessible_selectors/rspec/matchers.rb
@@ -8,7 +8,7 @@ module Capybara
   module RSpecMatchers
     %i[alert combo_box modal tab_panel tab_button disclosure disclosure_button section item].each do |selector|
       define_method "have_#{selector}" do |locator = nil, **options, &optional_filter_block|
-        Matchers::HaveSelector.new(selector, locator, options, &optional_filter_block)
+        Matchers::HaveSelector.new(selector, locator, **options, &optional_filter_block)
       end
 
       define_method "have_no_#{selector}" do |*args, &optional_filter_block|

--- a/lib/capybara_accessible_selectors/selectors/combo_box.rb
+++ b/lib/capybara_accessible_selectors/selectors/combo_box.rb
@@ -10,7 +10,7 @@ Capybara.add_selector(:combo_box, locator_type: [String, Symbol]) do # rubocop:d
       XPath.ancestor[XPath.attr(:role) == "combobox"], # ARIA 1.1
       XPath.attr(:class).contains_word("tt-input") # DEPRECATED: Twitter typeahead
     ].reduce(:|)]
-    locate_field(xpath, locator, options)
+    locate_field(xpath, locator, **options)
   end
 
   filter_set(:_field, %i[disabled name placeholder valid])
@@ -196,7 +196,7 @@ module CapybaraAccessibleSelectors
       find_options[:with] = currently_with if currently_with
       find_options[:allow_self] = true if from.nil?
       find_option_options = extract_find_option_options(find_options)
-      input = find(:combo_box, from, find_options)
+      input = find(:combo_box, from, **find_options)
       input.set(search, fill_options)
       listbox = find(:combo_box_list_box, input, { wait: find_options[:wait] }.compact)
       option = listbox.find(:list_box_option, with, disabled: false, **find_option_options)

--- a/lib/capybara_accessible_selectors/selectors/disclosure.rb
+++ b/lib/capybara_accessible_selectors/selectors/disclosure.rb
@@ -58,7 +58,7 @@ module CapybaraAccessibleSelectors
     #
     # @return [Capybara::Node::Element] The element clicked
     def toggle_disclosure(name = nil, expand: nil, **find_options)
-      button = _locate_disclosure_button(name, find_options)
+      button = _locate_disclosure_button(name, **find_options)
       if expand.nil?
         button.click
       elsif button.tag_name == "summary"
@@ -88,7 +88,7 @@ module CapybaraAccessibleSelectors
     # @param [String] Name Fieldset label
     # @param [Hash] options Finder options
     def within_disclosure(name, **options)
-      within(:disclosure, name, options) { yield }
+      within(:disclosure, name, **options) { yield }
     end
   end
 end

--- a/lib/capybara_accessible_selectors/selectors/modal.rb
+++ b/lib/capybara_accessible_selectors/selectors/modal.rb
@@ -26,7 +26,7 @@ module CapybaraAccessibleSelectors
     # @param [String] Name Modal label
     # @param [Hash] options Finder options
     def within_modal(name, **options)
-      within(:modal, name, options) { yield }
+      within(:modal, name, **options) { yield }
     end
   end
 end

--- a/lib/capybara_accessible_selectors/selectors/rich_text.rb
+++ b/lib/capybara_accessible_selectors/selectors/rich_text.rb
@@ -32,7 +32,7 @@ module CapybaraAccessibleSelectors
     # @param [Hash] find_options Finder options
     # @option options [String] :with The text to use
     def fill_in_rich_text(locator, with:, clear: true, **find_options)
-      input = find(:rich_text, locator, find_options)
+      input = find(:rich_text, locator, **find_options)
       with = nil if with == ""
       if input.tag_name == "iframe"
         fill_in_iframe_rich_text(input, with, clear)
@@ -53,11 +53,11 @@ module CapybaraAccessibleSelectors
           return Capybara.page.within_frame(self) { yield } if tag_name == "iframe"
           return yield if matches_selector?(:rich_text, wait: false)
 
-          Capybara.page.within_rich_text(locator, find_options) { yield }
+          Capybara.page.within_rich_text(locator, **find_options) { yield }
         end
       end
 
-      within(:rich_text, locator, find_options) do
+      within(:rich_text, locator, **find_options) do
         return within_frame(current_scope) { yield } if current_scope.tag_name == "iframe"
 
         yield

--- a/lib/capybara_accessible_selectors/selectors/section.rb
+++ b/lib/capybara_accessible_selectors/selectors/section.rb
@@ -15,7 +15,7 @@ module CapybaraAccessibleSelectors
     # @param [String] locator The section heading
     # @param [Hash] options Finder options
     def within_section(locator, **options)
-      within(:section, locator, options) { yield }
+      within(:section, locator, **options) { yield }
     end
   end
 end

--- a/lib/capybara_accessible_selectors/selectors/tab.rb
+++ b/lib/capybara_accessible_selectors/selectors/tab.rb
@@ -52,7 +52,7 @@ module CapybaraAccessibleSelectors
       if name.nil? && is_a?(Capybara::Node::Element) && matches_selector?(:tab_button)
         self
       else
-        find(:tab_button, name, find_options)
+        find(:tab_button, name, **find_options)
       end.click
     end
   end
@@ -63,7 +63,7 @@ module CapybaraAccessibleSelectors
     # @param [String] name The tab button label
     # @param [Hash] options Finder options
     def within_tab_panel(name, **options)
-      within(:tab_panel, name, options) { yield }
+      within(:tab_panel, name, **options) { yield }
     end
   end
 end


### PR DESCRIPTION
Within a Ruby 2.7 application, pre-2.7 keyword arguments are deprecated:

```
lib/capybara_accessible_selectors/locate_by_fieldset.rb|10| warning:
  Using the last argument as keyword parameters is deprecated; maybe **
  should be added to the call
```

This commit may not be exhaustive, but it's a start.

[ruby-2-7-kwargs]: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/#what-is-deprecated