### PR TITLE
Add support for disclosure_button focused: filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change log
 
+- `<summary>` elements are interactive elements that can receive focus, so add
+  support for `focused:` filtering
 - Filter `list_box_option` nodes based on whether or not `aria-selected="true"`
 
 ## v0.4.1

--- a/lib/capybara_accessible_selectors/selectors/disclosure.rb
+++ b/lib/capybara_accessible_selectors/selectors/disclosure.rb
@@ -37,6 +37,8 @@ Capybara.add_selector(:disclosure_button) do
     ].reduce(:&)] + XPath.descendant(:summary)[XPath.string.n.is(name.to_s)]
   end
 
+  filter_set(:capybara_accessible_selectors, %i[focused])
+
   expression_filter(:expanded, :boolean) do |xpath, expanded|
     open = expanded ? XPath.parent.attr(:open) : !XPath.parent.attr(:open)
     xpath[(XPath.attr(:"aria-expanded") == expanded.to_s) | open]


### PR DESCRIPTION
The `disclosure_button` selector finds `<summary>` descendants of
`<details>` elements. The `<summary>` elements are interactive elements
that can receive focus, so add support for `focused:` filtering.