### PR TITLE
Fix ruby 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+## v0.4.2
+
+- Fix Ruby 3 errors
 - Filter `list_box_option` nodes based on whether or not `aria-selected="true"`
 
 ## v0.4.1
@@ -17,7 +20,7 @@
 
 ## v0.2.0
 
-- Added additional selector options to combo box 
+- Added additional selector options to combo box
 - `select_combo_box_option` will not longer try to select a disabled option
 - Added cheat sheet
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    capybara_accessible_selectors (0.4.0)
+    capybara_accessible_selectors (0.4.2)
       capybara (~> 3)
 
 GEM

--- a/lib/capybara_accessible_selectors/rspec/matchers.rb
+++ b/lib/capybara_accessible_selectors/rspec/matchers.rb
@@ -11,8 +11,8 @@ module Capybara
         Matchers::HaveSelector.new(selector, locator, **options, &optional_filter_block)
       end
 
-      define_method "have_no_#{selector}" do |*args, &optional_filter_block|
-        Matchers::NegatedMatcher.new(send("have_#{selector}", *args, &optional_filter_block))
+      define_method "have_no_#{selector}" do |*args, **options, &optional_filter_block|
+        Matchers::NegatedMatcher.new(send("have_#{selector}", *args, **options, &optional_filter_block))
       end
     end
 

--- a/lib/capybara_accessible_selectors/selectors/combo_box.rb
+++ b/lib/capybara_accessible_selectors/selectors/combo_box.rb
@@ -204,11 +204,11 @@ module CapybaraAccessibleSelectors
       find_option_options = extract_find_option_options(find_options)
       input = find(:combo_box, from, **find_options)
       if search
-        input.set(search, fill_options)
+        input.set(search, **fill_options)
       else
         input.click
       end
-      listbox = find(:combo_box_list_box, input, { wait: find_options[:wait] }.compact)
+      listbox = find(:combo_box_list_box, input, **{ wait: find_options[:wait] }.compact)
       option = listbox.find(:list_box_option, with, disabled: false, **find_option_options)
       # Some drivers complain about clicking on a tr
       option = option.find(:css, "td", match: :first) if option.tag_name == "tr"

--- a/lib/capybara_accessible_selectors/selectors/disclosure.rb
+++ b/lib/capybara_accessible_selectors/selectors/disclosure.rb
@@ -75,7 +75,7 @@ module CapybaraAccessibleSelectors
         return self if matches_selector?(:disclosure_button, wait: false)
         return find(:element, :summary, **find_options) if tag_name == "details"
         if matches_selector?(:disclosure, wait: false)
-          return find(:xpath, XPath.anywhere[XPath.attr(:"aria-controls") == self[:id]], find_options)
+          return find(:xpath, XPath.anywhere[XPath.attr(:"aria-controls") == self[:id]], **find_options)
         end
       end
       find(:disclosure_button, name, **find_options)

--- a/lib/capybara_accessible_selectors/selectors/rich_text.rb
+++ b/lib/capybara_accessible_selectors/selectors/rich_text.rb
@@ -57,7 +57,7 @@ module CapybaraAccessibleSelectors
         end
       end
 
-      within(:rich_text, locator, find_options) do
+      within(:rich_text, locator, **find_options) do
         return within_frame(current_scope, &block) if current_scope.tag_name == "iframe"
 
         yield

--- a/lib/capybara_accessible_selectors/version.rb
+++ b/lib/capybara_accessible_selectors/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CapybaraAccessibleSelectors
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end


### PR DESCRIPTION
This fixes some syntax errors in Ruby 3.0.0.

I'm still getting these errors locally, but it could be unrelated as I also get them on the main branch (chrome version?)
```
rspec ./spec/filters/fieldset_spec.rb:57 # fieldset filter button selects a button
rspec ./spec/selectors/locate_by_fieldset_spec.rb:57 # fieldset filter button selects a button
```