### PR TITLE
Extend `toggle_disclosure` to accept a block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+- When passed a block, `toggle_disclosure` will forward the block to a
+  `within_disclosure` call with the same set of locator arguments and options
+
 ## v0.5.0
 
 - Fix selecting a modal or rich text by aria-label was using the exact text

--- a/README.md
+++ b/README.md
@@ -440,9 +440,14 @@ Toggle a disclosure open or closed.
 - `name` [String] - Locator for the disclosure button
 - options:
   - `expand` [Boolean] - Force open or closed rather than toggling.
+- `block` - When present, the `block` argument is forwarded to a
+  [`within_disclosure`](#within_disclosurename-find_options-block) call
 
 ```ruby
 toggle_disclosure("Client details")
+toggle_disclosure "Client details", expand: true do
+  expect(page).to have_text "The Client details contents"
+end
 ```
 
 Also see [↑ `disclosure` selector](#disclosure)

--- a/lib/capybara_accessible_selectors/selectors/disclosure.rb
+++ b/lib/capybara_accessible_selectors/selectors/disclosure.rb
@@ -59,7 +59,7 @@ module CapybaraAccessibleSelectors
     # @option options [Boolean] expand Set true to open, false to close, or nil to toggle
     #
     # @return [Capybara::Node::Element] The element clicked
-    def toggle_disclosure(name = nil, expand: nil, **find_options)
+    def toggle_disclosure(name = nil, expand: nil, **find_options, &block)
       button = _locate_disclosure_button(name, **find_options)
       if expand.nil?
         button.click
@@ -67,6 +67,10 @@ module CapybaraAccessibleSelectors
         button.click if button.find(:xpath, "..")[:open] == expand
       elsif button[:"aria-expanded"] != (expand ? "true" : "false") # rubocop:disable Lint/DuplicateBranch
         button.click
+      end
+
+      if block.present?
+        within_disclosure(name, expanded: expand, **find_options, &block)
       end
     end
 

--- a/spec/selectors/disclosure_spec.rb
+++ b/spec/selectors/disclosure_spec.rb
@@ -59,6 +59,22 @@ describe "Disclosure" do
         summary.toggle_disclosure
         expect(page).to have_selector :disclosure, "Summary button", expanded: true
       end
+
+      it "invokes #within_disclosure when passed a block" do
+        summary = page.find(:element, :summary, text: "Summary button")
+
+        expect(page).to have_no_text <<~TEXT.strip, exact: true
+          Summary button
+          Details content
+        TEXT
+
+        summary.toggle_disclosure do
+          expect(page).to have_no_text <<~TEXT.strip, exact: true
+            Summary button
+            Details content
+          TEXT
+        end
+      end
     end
 
     context "#within_disclosure" do


### PR DESCRIPTION
When passed a block, `toggle_disclosure` will forward the block to a
`within_disclosure` call with the same set of locator arguments and
options:

```ruby
 # before
toggle_disclosure "Client details", expand: true
within_disclosure "Client details", expanded: true do
  expect(page).to have_text "The client details contents"
end

 # after
toggle_disclosure "Client details", expand: true do
  expect(page).to have_text "The client details contents"
end
```