### PR TITLE
Update README with ARIA APG links

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Also see [↑ `fieldset` filter](#fieldset-string-symbol-array)
 
 #### `alert`
 
-Selects an element with the role of [`alert`](https://www.w3.org/TR/wai-aria-practices-1.1/#alert).
+Selects an element with the role of [`alert`](https://www.w3.org/WAI/ARIA/apg/patterns/alert/).
 
 ```html
 <div role="alert">Important message</div>
@@ -206,7 +206,7 @@ Also see [↓ Expectation shortcuts](#expectation-shortcuts)
 
 #### `combo_box`
 
-Finds a [combo box](https://www.w3.org/TR/wai-aria-practices-1.1/#combobox).
+Finds a [combo box](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/).
 This will find ARIA 1.0 and ARIA 1.1 combo boxes. A combo box is an input with a popup list of options.
 
 This also finds select based on [Twitter typeahead](https://twitter.github.io/typeahead.js/) classes, but this behaviour is deprecated and will be removed in a future release.
@@ -233,7 +233,7 @@ Also see:
 
 #### `disclosure`
 
-Finds a [disclosure](https://www.w3.org/TR/wai-aria-practices-1.1/#disclosure). This will find both a [native disclosure](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) (`<details>`/`<summary>`) and an ARIA disclosure.
+Finds a [disclosure](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/). This will find both a [native disclosure](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) (`<details>`/`<summary>`) and an ARIA disclosure.
 
 - `locator` [String, Symbol] The text label of the disclosure
 - Filters:
@@ -249,7 +249,7 @@ Also see:
 
 #### `disclosure_button`
 
-Finds the open and close button associated with a [disclosure](https://www.w3.org/TR/wai-aria-practices-1.1/#disclosure). This will be a `<summary>`, a `<button>` or an element with the role of button.
+Finds the open and close button associated with a [disclosure](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/). This will be a `<summary>`, a `<button>` or an element with the role of button.
 
 - `locator` [String, Symbol] The text label of the disclosure
 - Filters:
@@ -290,7 +290,7 @@ Also see [↓ Expectation shortcuts](#expectation-shortcuts)
 
 #### `modal`
 
-Finds a [modal dialog](https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal).
+Finds a [modal dialog](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/).
 
 This checks for a modal with the correct aria role, `aria-modal="true"` attribute, and it has an associated title.
 
@@ -360,7 +360,7 @@ Also see
 
 #### `tab_panel`
 
-Finds a [tab panel](https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel).
+Finds a [tab panel](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/).
 
 - `locator` [String, Symbol] The text label of the tab button associated with the panel
 - Filters:


### PR DESCRIPTION
The [WAI ARIA Authoring Practices Guide][apg] website has been
re-designed, and its URL structure has changed.

This commit updates the README file's reference links to their new
counterparts.

[apg]: https://www.w3.org/WAI/ARIA/apg/