### PR TITLE
Introduce `:menu` and `:menuitem` selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## Unreleased
+
+- Add `:menu` and `:menuitem` selector
+
 ## v0.8.2
 
 - Focus rich text when editing it

--- a/README.md
+++ b/README.md
@@ -288,6 +288,57 @@ expect(page).to have_selector :item_type, "application:person"
 
 Also see [↓ Expectation shortcuts](#expectation-shortcuts)
 
+#### `menu`
+
+Finds a [menu](https://www.w3.org/WAI/ARIA/apg/patterns/menu/).
+
+- `locator` [String, Symbol] Either the menu's `[aria-label]` value, the
+  contents of the `[role="menuitem"]` or `<button>` referenced by its
+  `[aria-labelledby]`
+- Filters:
+  - `expanded` [Boolean] Is the menu expanded
+  - `orientation` [String] The menu's orientation, either `horizontal` or
+    `vertical` (defaults to `vertical` when omitted
+
+```html
+<div role="menu" aria-label="Actions">
+  <button type="button" role="menuitem">Share</li>
+  <button type="button" role="menuitem">Save</li>
+  <button type="button" role="menuitem">Delete</li>
+</div>
+```
+
+```ruby
+expect(page).to have_selector :menu, "Actions"
+expect(page).to have_selector :menu, "Actions", expanded: true
+```
+
+#### `menuitem`
+
+Finds a [menuitem](https://w3c.github.io/aria/#menuitem).
+
+- `locator` [String, Symbol] The menuitem content or the
+- `locator` [String, Symbol] Either the menuitem's contents, its `[aria-label]`
+  value, or the contents of the element referenced by its `[aria-labelledby]`
+- Filters:
+  - `disabled` [Boolean] Is the menuitem disabled
+
+```html
+<div role="menu" aria-label="Actions">
+  <button type="button" role="menuitem">Share</li>
+  <button type="button" role="menuitem" aria-disabled="true">Save</li>
+  <button type="button" role="menuitem">Delete</li>
+</div>
+```
+
+```ruby
+within :menu, "Actions", expanded: true do
+  expect(page).to have_selector :menuitem, "Share"
+  expect(page).to have_selector :menuitem, "Save", disabled: true
+  expect(page).to have_no_selector :menuitem, "Do something else"
+end
+```
+
 #### `modal`
 
 Finds a [modal dialog](https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal).

--- a/lib/capybara_accessible_selectors/rspec/matchers.rb
+++ b/lib/capybara_accessible_selectors/rspec/matchers.rb
@@ -6,7 +6,7 @@ require "capybara_accessible_selectors/rspec/matchers/have_no_validation_errors"
 # rubocop:disable Naming/PredicateName
 module Capybara
   module RSpecMatchers
-    %i[alert combo_box modal tab_panel tab_button disclosure disclosure_button section item].each do |selector|
+    %i[alert combo_box modal tab_panel tab_button disclosure disclosure_button menu menuitem section item].each do |selector|
       define_method "have_#{selector}" do |locator = nil, **options, &optional_filter_block|
         Matchers::HaveSelector.new(selector, locator, **options, &optional_filter_block)
       end

--- a/lib/capybara_accessible_selectors/selectors.rb
+++ b/lib/capybara_accessible_selectors/selectors.rb
@@ -3,6 +3,7 @@
 require "capybara_accessible_selectors/selectors/alert"
 require "capybara_accessible_selectors/selectors/combo_box"
 require "capybara_accessible_selectors/selectors/disclosure"
+require "capybara_accessible_selectors/selectors/menu"
 require "capybara_accessible_selectors/selectors/microdata"
 require "capybara_accessible_selectors/selectors/modal"
 require "capybara_accessible_selectors/selectors/rich_text"

--- a/lib/capybara_accessible_selectors/selectors/menu.rb
+++ b/lib/capybara_accessible_selectors/selectors/menu.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+Capybara.add_selector(:menu, locator_type: [String, Symbol]) do
+  def aria_or_real_button
+    XPath.self(:button) | (XPath.attr(:role) == "button")
+  end
+
+  xpath do |*|
+    XPath.descendant[XPath.attr(:role) == "menu"]
+  end
+
+  locator_filter skip_if: nil do |node, locator, exact:, **|
+    method = exact ? :eql? : :include?
+    if node[:"aria-labelledby"]
+      CapybaraAccessibleSelectors::Helpers.element_labelledby(node).public_send(method, locator)
+    elsif node[:"aria-label"]
+      node[:"aria-label"].public_send(method, locator.to_s)
+    end
+  end
+
+  expression_filter(:expanded, :boolean) do |xpath, expanded|
+    button = XPath.anywhere[aria_or_real_button][XPath.attr(:"aria-expanded") == expanded.to_s]
+    xpath[button.attr(:"aria-controls") == XPath.attr(:id)]
+  end
+
+  node_filter(:orientation, [String, Symbol]) do |node, value|
+    orientation = (node[:"aria-orientation"] || "vertical").to_s
+
+    orientation == value.to_s
+  end
+end
+
+Capybara.add_selector(:menuitem, locator_type: [String, Symbol]) do
+  xpath do |*|
+    XPath.descendant[XPath.attr(:role) == "menuitem"]
+  end
+
+  locator_filter skip_if: nil do |node, locator, exact:, **|
+    method = exact ? :eql? : :include?
+    label =
+      if node[:"aria-labelledby"]
+        CapybaraAccessibleSelectors::Helpers.element_labelledby(node)
+      elsif node[:"aria-label"]
+        node[:"aria-label"]
+      else
+        node.text
+      end
+
+    label.public_send(method, locator.to_s)
+  end
+
+  node_filter(:disabled, :boolean, default: false) do |node, value|
+    (node[:"aria-disabled"] || "false") == value.to_s
+  end
+end

--- a/spec/fixtures/menu.html
+++ b/spec/fixtures/menu.html
@@ -1,0 +1,26 @@
+<meta charset="UTF-8" />
+<h1>Menu</h1>
+
+<button aria-controls="menu-expanded" aria-haspopup="menu" aria-expanded="true">Menu (already expanded)</button>
+
+<button role="menuitem">Menuitem (has no menu)</button>
+
+<div id="menu-expanded" role="menu" aria-label="Menu (expanded)">
+  <button role="menuitem">Menuitem (textContent)</button>
+  <button role="menuitem" aria-label="Menuitem ([aria-label])"</button>
+  <button role="menuitem" aria-labelledby="menu-expanded-menuitem"></button>
+  <button role="menuitem" aria-disabled="true">Menuitem (disabled)</button>
+</div>
+
+<p id="menu-expanded-menuitem">Menuitem ([aria-labelledby])</p>
+
+<button id="menubutton-collapsed" aria-controls="menu-collapsed" aria-haspopup="menu" aria-expanded="false">Menu (collapsed)</button>
+
+<div id="menu-collapsed" role="menu" aria-labelledby="menubutton-collapsed">
+</div>
+
+<div id="menu-vertical" role="menu" aria-label="Menu (vertical)" aria-orientation="vertical">
+</div>
+
+<div id="menu-horizontal" role="menu" aria-label="Menu (horizontal)" aria-orientation="horizontal">
+</div>

--- a/spec/matchers/have_menu_spec.rb
+++ b/spec/matchers/have_menu_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+describe "have_menu" do
+  before do
+    visit "/menu.html"
+  end
+
+  it "finds a menu by [aria-label]" do
+    expect(page).to have_menu("Menu (expanded)")
+  end
+
+  it "finds a menu by [aria-labelledby]" do
+    expect(page).to have_menu("Menu (collapsed)")
+  end
+
+  it "matches using a negated custom matcher" do
+    expect(page).to have_no_menu("foo")
+  end
+end

--- a/spec/matchers/have_menuitem_spec.rb
+++ b/spec/matchers/have_menuitem_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+describe "have_menu" do
+  before do
+    visit "/menu.html"
+  end
+
+  it "finds a menuitem by its text content" do
+    within :menu, "Menu (expanded)" do
+      expect(page).to have_menuitem, "Menuitem (textContent)"
+    end
+  end
+
+  it "finds a menuitem by [aria-label]" do
+    within :menu, "Menu (expanded)" do
+      expect(page).to have_menuitem, "Menuitem ([aria-label])"
+    end
+  end
+
+  it "finds a menuitem by [aria-labelledby]" do
+    within :menu, "Menu (expanded)" do
+      expect(page).to have_menuitem, "Menuitem ([aria-labelledby])"
+    end
+  end
+
+  it "matches using a negated custom matcher" do
+    expect(page).to have_no_menuitem("foo")
+  end
+end

--- a/spec/selectors/menu_spec.rb
+++ b/spec/selectors/menu_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+describe "menu selector" do
+  before do
+    visit "/menu.html"
+  end
+
+  describe "locator" do
+    it "finds menus without a locator" do
+      expect(page).to have_selector :menu, count: 4
+    end
+
+    it "finds a menu by [aria-label]" do
+      menu = find(id: "menu-expanded")
+
+      expect(find(:menu, "Menu (expanded)")).to eq menu
+    end
+
+    it "finds a menu by [aria-labelledby]" do
+      menu = find(id: "menu-collapsed")
+
+      expect(find(:menu, "Menu (collapsed)")).to eq menu
+    end
+  end
+
+  describe "expanded" do
+    context "when true" do
+      it "finds expanded" do
+        expect(page).to have_selector :menu, "Menu (expanded)", expanded: true
+      end
+
+      it "does not find not expanded" do
+        expect(page).to have_no_selector :menu, "Menu (collapsed)", expanded: true
+      end
+    end
+
+    context "when false" do
+      it "finds not expanded" do
+        expect(page).to have_selector :menu, "Menu (collapsed)", expanded: false
+      end
+
+      it "does not find expanded" do
+        expect(page).to have_no_selector :menu, "Menu (expanded)", expanded: false
+      end
+    end
+  end
+
+  describe "orientation" do
+    context "when vertical" do
+      it "finds vertical" do
+        expect(page).to have_selector(:menu, "Menu (vertical)", orientation: :vertical)
+        expect(page).to have_selector(:menu, "Menu (vertical)", orientation: "vertical")
+        expect(page).to have_selector(:menu, "Menu (expanded)", orientation: :vertical)
+        expect(page).to have_selector(:menu, "Menu (expanded)", orientation: "vertical")
+      end
+
+      it "does not find horizontal" do
+        expect(page).to have_no_selector(:menu, "Menu (horizontal)", orientation: :vertical)
+        expect(page).to have_no_selector(:menu, "Menu (horizontal)", orientation: "vertical")
+      end
+    end
+
+    context "when horizontal" do
+      it "does not find vertical" do
+        expect(page).to have_no_selector(:menu, "Menu (vertical)", orientation: :horizontal)
+        expect(page).to have_no_selector(:menu, "Menu (vertical)", orientation: "horizontal")
+        expect(page).to have_no_selector(:menu, "Menu (expanded)", orientation: :horizontal)
+        expect(page).to have_no_selector(:menu, "Menu (expanded)", orientation: "horizontal")
+      end
+
+      it "finds horizontal" do
+        expect(page).to have_selector(:menu, "Menu (horizontal)", orientation: :horizontal)
+        expect(page).to have_selector(:menu, "Menu (horizontal)", orientation: "horizontal")
+      end
+    end
+  end
+end

--- a/spec/selectors/menuitem_spec.rb
+++ b/spec/selectors/menuitem_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+describe "menuitem selector" do
+  before do
+    visit "/menu.html"
+  end
+
+  describe "locator" do
+    it "finds menuitems without a locator" do
+      within :menu, "Menu (expanded)" do
+        expect(page).to have_selector :menuitem, count: 3
+      end
+    end
+
+    it "finds a menuitem by its text content" do
+      within :menu, "Menu (expanded)" do
+        expect(page).to have_selector :menuitem, "Menuitem (textContent)"
+      end
+    end
+
+    it "finds a menuitem by [aria-label]" do
+      within :menu, "Menu (expanded)" do
+        expect(page).to have_selector :menuitem, "Menuitem ([aria-label])"
+      end
+    end
+
+    it "finds a menuitem by [aria-labelledby]" do
+      within :menu, "Menu (expanded)" do
+        expect(page).to have_selector :menuitem, "Menuitem ([aria-labelledby])"
+      end
+    end
+  end
+
+  describe "disabled" do
+    context "when omitted" do
+      it "finds not disabled" do
+        within :menu, "Menu (expanded)" do
+          expect(page).to have_selector :menuitem, "Menuitem (textContent)"
+        end
+      end
+
+      it "does not find disabled" do
+        within :menu, "Menu (expanded)" do
+          expect(page).to have_no_selector :menuitem, "Menuitem (disabled)"
+        end
+      end
+    end
+
+    context "when true" do
+      it "finds disabled" do
+        within :menu, "Menu (expanded)" do
+          expect(page).to have_selector :menuitem, "Menuitem (disabled)", disabled: true
+        end
+      end
+
+      it "does not find not disabled" do
+        within :menu, "Menu (expanded)" do
+          expect(page).to have_no_selector :menuitem, "Menuitem (textContent)", disabled: true
+        end
+      end
+    end
+
+    context "when false" do
+      it "finds not disabled" do
+        within :menu, "Menu (expanded)" do
+          expect(page).to have_selector :menuitem, "Menuitem (textContent)", disabled: false
+        end
+      end
+
+      it "does not find disabled" do
+        within :menu, "Menu (expanded)" do
+          expect(page).to have_no_selector :menuitem, "Menuitem (disabled)", disabled: false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Declare a structure-based [menu][] selector with light [menubutton][]
integration.

The XPath selectors and filters are based on the various states outlined
in the [Authoring Practices Guide][] as well as the [role="menu"][] and
[role="menuitem"][] documentation.

[menu]: https://www.w3.org/WAI/ARIA/apg/patterns/menu/
[menubutton]: https://www.w3.org/WAI/ARIA/apg/patterns/menubutton/
[Authoring Practices Guide]: https://www.w3.org/WAI/ARIA/apg/
[role="menu"]: https://w3c.github.io/aria/#menu
[role="menuitem"]: https://w3c.github.io/aria/#menuitem