### PR TITLE
Add `current:` filter for `link` and `link_or_button`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## Unreleased
+
+- Add `current:` filter for `:link` and `:link_or_button` selectors
+
 ## v0.8.2
 
 - Focus rich text when editing it

--- a/README.md
+++ b/README.md
@@ -69,6 +69,29 @@ See the [Capybara cheatsheet](https://devhints.io/capybara) for an overview of b
 
 ### Filters
 
+#### `current` [String, Symbol]
+
+Added to: `link`, `link_or_button`.
+
+Is the element the current item within a container or set of related elements using [`aria-current`](https://www.w3.org/TR/wai-aria/#aria-current).
+
+For example:
+
+```html
+<ul>
+  <li>
+    <a href="/">Home</a>
+  </li>
+  <li>
+    <a href="/about-us" aria-current="page">About us</a>
+  </li>
+</ul>
+```
+
+```ruby
+expect(page).to have_link "About us", current: "page"
+```
+
 #### `described_by` [String]
 
 Added to: `field`, `fillable_field`, `datalist_input`, `radio_button`, `checkbox`, `select`, `file_field`, `combo_box` and `rich_text`.

--- a/lib/capybara_accessible_selectors/filter_set.rb
+++ b/lib/capybara_accessible_selectors/filter_set.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Capybara::Selector::FilterSet.add(:capybara_accessible_selectors)
+require "capybara_accessible_selectors/filters/current"
 require "capybara_accessible_selectors/filters/described_by"
 require "capybara_accessible_selectors/filters/fieldset"
 require "capybara_accessible_selectors/filters/focused"
@@ -15,8 +16,8 @@ require "capybara_accessible_selectors/filters/validation_error"
   field: %i[focused fieldset described_by validation_error],
   file_field: %i[focused fieldset described_by validation_error],
   fillable_field: %i[focused fieldset described_by validation_error],
-  link: %i[focused fieldset],
-  link_or_button: %i[focused fieldset],
+  link: %i[current focused fieldset],
+  link_or_button: %i[current focused fieldset],
   radio_button: %i[focused fieldset described_by validation_error],
   select: %i[focused fieldset described_by validation_error],
   xpath: %i[focused]

--- a/lib/capybara_accessible_selectors/filters/current.rb
+++ b/lib/capybara_accessible_selectors/filters/current.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Capybara::Selector::FilterSet[:capybara_accessible_selectors].instance_eval do
+  expression_filter(:current, skip_if: nil) do |xpath, value|
+    xpath[XPath.attr(:"aria-current") == value.to_s]
+  end
+end

--- a/spec/filters/current_spec.rb
+++ b/spec/filters/current_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+describe "current" do
+  before { visit "/current.html" }
+
+  it "selects a link with aria-current=page" do
+    expect(page).to have_selector :link, "About us", current: "page"
+  end
+
+  it "selects a link_or_button with aria-current=page" do
+    expect(page).to have_selector :link_or_button, "About us", current: "page"
+  end
+end

--- a/spec/fixtures/current.html
+++ b/spec/fixtures/current.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<meta charset="UTF-8">
+<h1>Link</h1>
+
+<a href="/">Home</a>
+<a href="/about-us" aria-current="page">About us</a>


### PR DESCRIPTION
`current` [String, Symbol]

Added to: `link`, `link_or_button`.

Is the element the current item within a container or set of related elements using [`aria-current`](https://www.w3.org/TR/wai-aria/#aria-current).

For example:

```html
<ul>
  <li>
    <a href="/">Home</a>
  </li>
  <li>
    <a href="/about-us" aria-current="page">About us</a>
  </li>
</ul>
```

```ruby
expect(page).to have_link "About us", current: "page"
```