### PR TITLE
add support for native dialog element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `:menu` and `:menuitem` selector
 - Add `current:` filter for `:link` and `:link_or_button` selectors
 - Removed `focused:` in favour of the "native" capybara focus
+- Allow the `:modal` selector to select open `<dialog>` elements
 
 ## v0.8.2
 

--- a/README.md
+++ b/README.md
@@ -386,7 +386,12 @@ end
 
 Finds a [modal dialog](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/).
 
-This checks for a modal with the correct aria role, `aria-modal="true"` attribute, and it has an associated title.
+This checks for either
+
+- a modal with the correct aria role, `aria-modal="true"` attribute, and it has an associated title.
+- or, an open `<dialog>` element.
+
+Note that it is not possible to distinguish between a `<dialog>` opened as a modal and as non-modal.
 
 - `locator` [String, Symbol] The title of the modal
 

--- a/lib/capybara_accessible_selectors/selectors/modal.rb
+++ b/lib/capybara_accessible_selectors/selectors/modal.rb
@@ -2,10 +2,15 @@
 
 Capybara.add_selector(:modal, locator_type: [String, Symbol]) do
   xpath do |*|
-    XPath.descendant[[
-      XPath.attr(:"aria-modal") == "true",
-      (XPath.attr(:role) == "dialog") | (XPath.attr(:role) == "alertdialog")
-    ].reduce(:&)]
+    XPath.descendant[
+      [
+        XPath.self(:dialog)[XPath.attr(:open)],
+        [
+          XPath.attr(:"aria-modal") == "true",
+          (XPath.attr(:role) == "dialog") | (XPath.attr(:role) == "alertdialog")
+        ].reduce(:&)
+      ].reduce(&:|)
+    ]
   end
 
   locator_filter do |node, locator, exact:, **|

--- a/spec/fixtures/modal.html
+++ b/spec/fixtures/modal.html
@@ -39,3 +39,14 @@
   </h2>
   Missing aria-modal content
 </div>
+
+<dialog id="native-dialog" aria-labelledby="native-modal-heading">
+  <h2 id="native-modal-heading">
+    Native modal heading
+  </h2>
+  Native modal content
+</dialog>
+
+<button type="button" onclick="document.getElementById('native-dialog').showModal()">
+  Open native
+</button>

--- a/spec/selectors/modal_spec.rb
+++ b/spec/selectors/modal_spec.rb
@@ -70,6 +70,16 @@ describe "modal selector" do
     expect(page).to have_no_selector :modal, "Missing aria modal"
   end
 
+  it "selects a native modal" do
+    click_button "Open native"
+    modal = find(:element, :dialog)
+    expect(find(:modal, "Native modal heading")).to eq modal
+  end
+
+  it "does not selects an unopened native modal" do
+    expect(page).to have_no_selector :modal, "Native modal content", visible: :all
+  end
+
   describe "within_modal" do
     it "limits to within the modal" do
       within_modal "Dialog title" do


### PR DESCRIPTION
This is now supported in all browsers.

Although in practice a polyfill or alternative will be needed for older versions of safari for some time.