### PR TITLE
Add support for `role:` filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `role:` filter
 - Add `:article` selector and `have_article` matcher
 - Add `:grid`, `:gridcell`, `:columnheader`, and `:row`
 - Add `:menu` and `:menuitem` selector

--- a/README.md
+++ b/README.md
@@ -142,6 +142,21 @@ choose "Answer 1", fieldset: "My question"
 
 Also see [↓ Locating fields](#locating-fields)
 
+#### `role` [String]
+
+Added to: `button`, `checkbox`, `css`, `element`, `field`, `file_field`, `fillable_field`, `link`, `link_or_button`, `radio_button`, `select`, and `xpath`
+
+Filters for an element that declares a matching [role](https://www.w3.org/TR/wai-aria/#usage_intro) attribute.
+
+```html
+<label for="switch-input">A switch input</label>
+<input id="switch-input" type="checkbox" role="switch">
+```
+
+```ruby
+expect(page).to have_field "A switch input", role: "switch"
+```
+
 #### `validation_error` [String]
 
 Added to: `field`, `fillable_field`, `datalist_input`, `radio_button`, `checkbox`, `select`, `file_field`, `combo_box` and `rich_text`.

--- a/lib/capybara_accessible_selectors/filter_set.rb
+++ b/lib/capybara_accessible_selectors/filter_set.rb
@@ -4,19 +4,23 @@ Capybara::Selector::FilterSet.add(:capybara_accessible_selectors)
 require "capybara_accessible_selectors/filters/current"
 require "capybara_accessible_selectors/filters/described_by"
 require "capybara_accessible_selectors/filters/fieldset"
+require "capybara_accessible_selectors/filters/role"
 require "capybara_accessible_selectors/filters/validation_error"
 
 {
-  button: %i[fieldset],
-  checkbox: %i[fieldset described_by validation_error],
+  button: %i[fieldset role],
+  checkbox: %i[fieldset described_by role validation_error],
+  css: %i[role],
   datalist_input: %i[fieldset described_by validation_error],
-  field: %i[fieldset described_by validation_error],
-  file_field: %i[fieldset described_by validation_error],
-  fillable_field: %i[fieldset described_by validation_error],
-  link: %i[current fieldset],
-  link_or_button: %i[current fieldset],
-  radio_button: %i[fieldset described_by validation_error],
-  select: %i[fieldset described_by validation_error]
+  element: %i[role],
+  field: %i[fieldset described_by role validation_error],
+  file_field: %i[fieldset described_by role validation_error],
+  fillable_field: %i[fieldset described_by role validation_error],
+  link: %i[current fieldset role],
+  link_or_button: %i[current fieldset role],
+  radio_button: %i[fieldset described_by role validation_error],
+  select: %i[fieldset described_by role validation_error],
+  xpath: %i[role]
 }.each do |selector, filters|
   Capybara.modify_selector(selector) do
     filter_set(:capybara_accessible_selectors, filters)

--- a/lib/capybara_accessible_selectors/filters/role.rb
+++ b/lib/capybara_accessible_selectors/filters/role.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Capybara::Selector::FilterSet[:capybara_accessible_selectors].instance_eval do
+  expression_filter(:role, skip_if: nil) do |scope, value|
+    case scope
+    when String then %(#{scope}[role="#{value}"])
+    else             scope[XPath.attr(:role) == value.to_s]
+    end
+  end
+end

--- a/spec/filters/role_spec.rb
+++ b/spec/filters/role_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+describe "role" do
+  it "selects an element with a matching role by xpath selector" do
+    render <<~HTML
+      <div role="tablist">Tablist</div>
+    HTML
+
+    expect(page).to have_selector :xpath, XPath.descendant(:div), role: "tablist"
+  end
+
+  it "selects an element with a matching role by css selector" do
+    render <<~HTML
+      <div role="tablist">Tablist</div>
+    HTML
+
+    expect(page).to have_selector :css, "div", role: "tablist"
+  end
+
+  it "selects a button with a matching role by selector" do
+    render <<~HTML
+      <button type="button" role="tab">Tab</button>
+    HTML
+
+    expect(page).to have_selector :button, "Tab", type: "button", role: "tab"
+  end
+
+  it "selects a checkbox with a matching role" do
+    render <<~HTML
+      <input type="checkbox" role="presentation">
+    HTML
+
+    expect(page).to have_selector :checkbox, role: "presentation"
+  end
+
+  it "selects a field with a matching role" do
+    render <<~HTML
+      <input role="presentation">
+    HTML
+
+    expect(page).to have_selector :field, role: "presentation"
+  end
+
+  it "selects a file field with a matching role" do
+    render <<~HTML
+      <input type="file" role="presentation">
+    HTML
+
+    expect(page).to have_selector :file_field, role: "presentation"
+  end
+
+  it "selects a fillable field with a matching role" do
+    render <<~HTML
+      <input role="presentation">
+    HTML
+
+    expect(page).to have_selector :fillable_field, role: "presentation"
+  end
+
+  it "selects a link with a matching role" do
+    render <<~HTML
+      <a href="#" role="presentation">Link</a>
+    HTML
+
+    expect(page).to have_selector :link, "Link", role: "presentation"
+  end
+
+  it "selects a link_or_button with a matching role" do
+    render <<~HTML
+      <a href="#" role="presentation">Link</a>
+    HTML
+
+    expect(page).to have_selector :link_or_button, "Link", role: "presentation"
+  end
+
+  it "selects a radio button with a matching role" do
+    render <<~HTML
+      <input type="radio" role="presentation">
+    HTML
+
+    expect(page).to have_selector :radio_button, role: "presentation"
+  end
+
+  it "selects a select with a matching role" do
+    render <<~HTML
+      <select role="presentation"></select>
+    HTML
+
+    expect(page).to have_selector :select, role: "presentation"
+  end
+
+  it "does not select an element without a role" do
+    render <<~HTML
+      <div>Not a tablist</div>
+    HTML
+
+    expect(page).to have_no_selector :element, role: "tablist"
+  end
+
+  it "does not select an element with a different role" do
+    render <<~HTML
+      <button type="button" role="tab">Tab</button>
+    HTML
+
+    expect(page).to have_no_selector :element, role: "tablist"
+  end
+
+  it "provides a friendly error for role" do
+    render <<~HTML
+      <button type="button" role="tab">Tab</button>
+    HTML
+
+    expect do
+      expect(page).to have_selector :button, "Tab", role: "tablist", wait: false
+    end.to raise_error RSpec::Expectations::ExpectationNotMetError, /with role tablist/
+  end
+end


### PR DESCRIPTION
Added to: `button`, `checkbox`, `css`, `element`, `field`, `file_field`, `fillable_field`, `link`, `link_or_button`, `radio_button`, `select`, and `xpath`

Filters for an element that declares a matching
[role](https://www.w3.org/TR/wai-aria/#usage_intro) attribute.

```html
<label for="switch-input">A switch input</label>
<input id="switch-input" type="checkbox" role="switch">
```

```ruby
expect(page).to have_field "A switch input", role: "switch"
```