### PR TITLE
Support for `aria:` Hash attributes filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `aria:` Hash filter
 - Add `:article` selector and `have_article` matcher
 - Add `:grid`, `:gridcell`, `:columnheader`, and `:row`
 - Add `:menu` and `:menuitem` selector

--- a/README.md
+++ b/README.md
@@ -69,6 +69,20 @@ See the [Capybara cheatsheet](https://devhints.io/capybara) for an overview of b
 
 ### Filters
 
+#### `aria` [Hash]
+
+Added to: `button`, `checkbox`, `css`, `element`, `field`, `file_field`, `fillable_field`, `link`, `link_or_button`, `radio_button`, `select`, and `xpath`
+
+Filters for an element that declares [ARIA attributes](https://www.w3.org/TR/wai-aria/#introstates)
+
+```html
+<button aria-controls="some-state" aria-pressed="true">A pressed button</button>
+```
+
+```ruby
+expect(page).to have_selector :button, "A pressed button", aria: { controls: "some-state", pressed: true }
+```
+
 #### `current` [String, Symbol]
 
 Added to: `link`, `link_or_button`.

--- a/lib/capybara_accessible_selectors/filter_set.rb
+++ b/lib/capybara_accessible_selectors/filter_set.rb
@@ -1,22 +1,26 @@
 # frozen_string_literal: true
 
 Capybara::Selector::FilterSet.add(:capybara_accessible_selectors)
+require "capybara_accessible_selectors/filters/aria"
 require "capybara_accessible_selectors/filters/current"
 require "capybara_accessible_selectors/filters/described_by"
 require "capybara_accessible_selectors/filters/fieldset"
 require "capybara_accessible_selectors/filters/validation_error"
 
 {
-  button: %i[fieldset],
-  checkbox: %i[fieldset described_by validation_error],
+  button: %i[fieldset aria],
+  checkbox: %i[fieldset described_by aria validation_error],
+  css: %i[aria],
   datalist_input: %i[fieldset described_by validation_error],
-  field: %i[fieldset described_by validation_error],
-  file_field: %i[fieldset described_by validation_error],
-  fillable_field: %i[fieldset described_by validation_error],
-  link: %i[current fieldset],
-  link_or_button: %i[current fieldset],
-  radio_button: %i[fieldset described_by validation_error],
-  select: %i[fieldset described_by validation_error]
+  element: %i[aria],
+  field: %i[fieldset described_by aria validation_error],
+  file_field: %i[fieldset described_by aria validation_error],
+  fillable_field: %i[fieldset described_by aria validation_error],
+  link: %i[current fieldset aria],
+  link_or_button: %i[current fieldset aria],
+  radio_button: %i[fieldset described_by aria validation_error],
+  select: %i[fieldset described_by aria validation_error],
+  xpath: %i[aria]
 }.each do |selector, filters|
   Capybara.modify_selector(selector) do
     filter_set(:capybara_accessible_selectors, filters)

--- a/lib/capybara_accessible_selectors/filters/aria.rb
+++ b/lib/capybara_accessible_selectors/filters/aria.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+Capybara::Selector::FilterSet[:capybara_accessible_selectors].instance_eval do
+  expression_filter(:aria, Hash, skip_if: nil) do |scope, nested_attributes|
+    prefixed_attributes = nested_attributes.transform_keys { |key| "aria-#{key}" }
+
+    case scope
+    when String
+      selectors = prefixed_attributes.map { |key, value| %([#{key}="#{value}"]) }
+
+      [scope, *selectors].join
+    else
+      expressions = prefixed_attributes.map { |key, value| XPath.attr(key.to_sym) == value.to_s }
+
+      scope[expressions.reduce(:&)]
+    end
+  end
+
+  describe(:expression_filters) do |aria: {}, **|
+    attributes = aria.map { |key, value| %(aria-#{key}="#{value}") }
+
+    " with #{attributes.join(' and ')}" unless attributes.empty?
+  end
+end

--- a/spec/filters/aria_spec.rb
+++ b/spec/filters/aria_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+describe "aria" do
+  it "selects an element with matching aria- attributes by xpath selector" do
+    render <<~HTML
+      <button aria-selected="true" aria-pressed="true">A button</button>
+    HTML
+
+    expect(page).to have_selector :xpath, XPath.descendant(:button), aria: { selected: true, pressed: true }
+  end
+
+  it "selects an element with matching aria- attributes by css selector" do
+    render <<~HTML
+      <button aria-selected="true" aria-pressed="true">A button</button>
+    HTML
+
+    expect(page).to have_selector :css, "button", aria: { selected: true, pressed: true }
+  end
+
+  it "selects a button with matching aria- attributes" do
+    render <<~HTML
+      <button aria-pressed="true">A button</button>
+    HTML
+
+    expect(page).to have_selector :button, "A button", aria: { pressed: true }
+  end
+
+  it "selects a checkbox with matching aria- attributes" do
+    render <<~HTML
+      <input type="checkbox" aria-hidden="true">
+    HTML
+
+    expect(page).to have_selector :checkbox, aria: { hidden: true }
+  end
+
+  it "selects a field with matching aria- attributes" do
+    render <<~HTML
+      <input aria-hidden="true">
+    HTML
+
+    expect(page).to have_selector :field, aria: { hidden: true }
+  end
+
+  it "selects a file field with matching aria- attributes" do
+    render <<~HTML
+      <input type="file" aria-hidden="true">
+    HTML
+
+    expect(page).to have_selector :file_field, aria: { hidden: true }
+  end
+
+  it "selects a fillable field with matching aria- attributes" do
+    render <<~HTML
+      <input aria-hidden="true">
+    HTML
+
+    expect(page).to have_selector :fillable_field, aria: { hidden: true }
+  end
+
+  it "selects a link with matching aria- attributes" do
+    render <<~HTML
+      <a href="#" aria-hidden="true">Link</a>
+    HTML
+
+    expect(page).to have_selector :link, "Link", aria: { hidden: true }
+  end
+
+  it "selects a link_or_button with matching aria- attributes" do
+    render <<~HTML
+      <a href="#" aria-hidden="true">Link</a>
+    HTML
+
+    expect(page).to have_selector :link_or_button, "Link", aria: { hidden: true }
+  end
+
+  it "selects a radio button with matching aria- attributes" do
+    render <<~HTML
+      <input type="radio" aria-hidden="true">
+    HTML
+
+    expect(page).to have_selector :radio_button, aria: { hidden: true }
+  end
+
+  it "selects a select with matching aria- attributes" do
+    render <<~HTML
+      <select aria-hidden="true"></select>
+    HTML
+
+    expect(page).to have_selector :select, aria: { hidden: true }
+  end
+
+  it "does not select an element without matching aria- attributes" do
+    render <<~HTML
+      <div>Not a tablist</div>
+    HTML
+
+    expect(page).to have_no_selector :element, aria: { hidden: true }
+  end
+
+  it "does not select an element with matching aria- attributes" do
+    render <<~HTML
+      <button type="button" role="tab">Tab</button>
+    HTML
+
+    expect(page).to have_no_selector :element, aria: { hidden: true }
+  end
+
+  it "provides a friendly error for the aria-prefixed attributes" do
+    render <<~HTML
+      <div>An element</div>
+    HTML
+
+    expect do
+      expect(page).to have_selector "div", aria: { selected: false, pressed: false }, wait: false
+    end.to raise_error RSpec::Expectations::ExpectationNotMetError, /with aria-selected="false" and aria-pressed="false"/
+  end
+end


### PR DESCRIPTION
Added to: `button`, `checkbox`, `css`, `element`, `field`, `file_field`, `fillable_field`, `link`, `link_or_button`, `radio_button`, `select`, and `xpath`

Filters for an element that declares [ARIA
attributes](https://www.w3.org/TR/wai-aria/#introstates)

```html
<button aria-controls="some-state" aria-pressed="true">A pressed button</button>
```

```ruby
expect(page).to have_selector :button, "A pressed button", aria: { controls: "some-state", pressed: true }
```