### PR TITLE
Added `aria:` filter to combo_box, disclosure, and disclosure_button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change log
 
+- Added `aria` filter to `:combo_box`, `:disclosure`, and `:disclosure_button` [Sean Doyle]
+
 ## v0.10.0
 
 - Added a `required` filter to all form input selectors

--- a/lib/capybara_accessible_selectors/selectors/combo_box.rb
+++ b/lib/capybara_accessible_selectors/selectors/combo_box.rb
@@ -14,7 +14,7 @@ Capybara.add_selector(:combo_box, locator_type: [String, Symbol]) do # rubocop:d
   end
 
   filter_set(:_field, %i[disabled name placeholder valid])
-  filter_set(:capybara_accessible_selectors, %i[fieldset described_by validation_error required])
+  filter_set(:capybara_accessible_selectors, %i[aria fieldset described_by validation_error required])
 
   # with a value
   node_filter(:with) do |node, with|

--- a/lib/capybara_accessible_selectors/selectors/disclosure.rb
+++ b/lib/capybara_accessible_selectors/selectors/disclosure.rb
@@ -50,7 +50,7 @@ Capybara.add_selector(:disclosure_button) do
     expanded ? " expanded" : " closed"
   end
 
-  filter_set(:capybara_accessible_selectors, %i[described_by])
+  filter_set(:capybara_accessible_selectors, %i[aria described_by])
 end
 
 module CapybaraAccessibleSelectors

--- a/lib/capybara_accessible_selectors/selectors/modal.rb
+++ b/lib/capybara_accessible_selectors/selectors/modal.rb
@@ -24,7 +24,7 @@ Capybara.add_selector(:modal, locator_type: [String, Symbol]) do
     end
   end
 
-  filter_set(:capybara_accessible_selectors, %i[described_by])
+  filter_set(:capybara_accessible_selectors, %i[aria described_by])
 end
 
 module CapybaraAccessibleSelectors


### PR DESCRIPTION
Prior to this commit, passing `aria: {...}` filters to `:combo_box`,
`:disclosure`, and `:disclosure_button` was unsupported.

Additional `aria:`-based filters other than `aria: {selected:}` and
`aria: {expanded:}` can be useful for these selectors (for example,
assertions that a `:disclosure_button` with a `aria: {controls:}` filter
that matches another element's `id:`).
