### PR TITLE
fix section needs accessible name to be a region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - added `radio_group` to 'have_validation_errors` to match multiple radios
 - added some missing selectors to 'have_validation_errors`
 - corrected logic for `add_validation_errors` finding invalid fields
+- fix a `<section>` can only be a `:region` if it has an accessible name
 
 ## v0.10.0
 

--- a/lib/capybara_accessible_selectors/selectors/region.rb
+++ b/lib/capybara_accessible_selectors/selectors/region.rb
@@ -3,17 +3,23 @@
 Capybara.add_selector :region, locator_type: [String, Symbol] do
   xpath do |*|
     XPath.descendant[[
-      XPath.local_name == "section",
+      XPath.self(:section) & (XPath.attr(:"aria-label") | XPath.attr(:"aria-labelledby")),
       XPath.attr(:role) == "region"
     ].reduce(:|)]
   end
 
-  locator_filter skip_if: nil do |node, locator, exact:, **|
-    method = exact ? :eql? : :include?
-    if node[:"aria-labelledby"]
-      CapybaraAccessibleSelectors::Helpers.element_labelledby(node).public_send(method, locator)
-    elsif node[:"aria-label"]
-      node[:"aria-label"].public_send(method, locator.to_s)
+  locator_filter do |node, locator, exact:, **|
+    next true if !locator && node.tag_name != "section"
+
+    name = if node[:"aria-labelledby"]
+             CapybaraAccessibleSelectors::Helpers.element_labelledby(node)
+           else
+             node[:"aria-label"]
+           end
+    if locator
+      name&.public_send(exact ? :eql? : :include?, locator)
+    else
+      name && !name.strip.empty?
     end
   end
 

--- a/spec/matchers/have_region_spec.rb
+++ b/spec/matchers/have_region_spec.rb
@@ -22,16 +22,6 @@ describe "region matchers" do
   end
 
   describe "within_region" do
-    it "scopes to inside a region without text" do
-      render <<~HTML
-        <section>Some text</section>
-      HTML
-
-      within_region do
-        expect(page).to have_text("Some text")
-      end
-    end
-
     it "scopes to inside a region with text" do
       render <<~HTML
         <section aria-label="A region">Some text</section>

--- a/spec/selectors/region_spec.rb
+++ b/spec/selectors/region_spec.rb
@@ -3,20 +3,21 @@
 describe "region selector" do
   describe "locator" do
     context "when <section> element" do
-      it "finds the first element" do
+      it "does not find with no accessible label" do
         render <<~HTML
           <section>Content</section>
         HTML
 
-        expect(page).to have_selector :region, count: 1
+        expect(page).to have_no_selector :region
       end
 
       it "finds based on [aria-label]" do
         render <<~HTML
           <section aria-label="Section region">Content</section>
+          <section aria-label="Other region">Content</section>
         HTML
 
-        expect(page).to have_selector :region, "Section region"
+        expect(page).to have_selector :region, "Section region", count: 1
       end
 
       it "does not find differing on [aria-label]" do
@@ -32,9 +33,12 @@ describe "region selector" do
           <section aria-labelledby="section_label">
             <h1 id="section_label">Section region</h1>
           </section>
+          <section aria-labelledby="section_other">
+            <h1 id="section_other">Other region</h1>
+          </section>
         HTML
 
-        expect(page).to have_selector :region, "Section region"
+        expect(page).to have_selector :region, "Section region", count: 1
       end
 
       it "does not find differing on [aria-labelledby]" do
@@ -45,6 +49,23 @@ describe "region selector" do
         HTML
 
         expect(page).to have_no_selector :region, "Not the right locator"
+      end
+
+      it "does not find with empty aria-label" do
+        render <<~HTML
+          <section aria-label=" ">Content</section>
+        HTML
+
+        expect(page).to have_no_selector :region
+      end
+
+      it "does not find with empty aria-labelledby" do
+        render <<~HTML
+          <section aria-labelledby="id">Content</section>
+          <div id="id"></div>
+        HTML
+
+        expect(page).to have_no_selector :region
       end
     end
 


### PR DESCRIPTION
Fix a `<section>` can only be a `:region` if it has an accessible name.