### PR TITLE
Stricter filter types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added `:heading` selector
 - Fix `:section` selector matching sections with no headings
 - `:section` selector will also match aria headings
+- Selector filters will now validate their values more strictly
 
 ## v0.10.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.2)
+    activesupport (7.1.3)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -31,7 +31,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     base64 (0.2.0)
-    bigdecimal (3.1.5)
+    bigdecimal (3.1.6)
     capybara (3.39.2)
       addressable
       matrix
@@ -41,7 +41,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     debug (1.9.1)
       irb (~> 1.10)
@@ -51,16 +51,16 @@ GEM
       ruby2_keywords
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    io-console (0.7.1)
-    irb (1.11.0)
+    io-console (0.7.2)
+    irb (1.11.1)
       rdoc
-      reline (>= 0.3.8)
+      reline (>= 0.4.2)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
     matrix (0.4.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
-    minitest (5.20.0)
+    minitest (5.21.2)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     mutex_m (0.2.0)
@@ -71,13 +71,13 @@ GEM
     nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
     parallel (1.24.0)
-    parser (3.3.0.2)
+    parser (3.3.0.4)
       ast (~> 2.4.1)
       racc
     psych (5.1.2)
       stringio
     public_suffix (5.0.4)
-    puma (6.4.1)
+    puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
     rack (2.2.8)
@@ -89,7 +89,7 @@ GEM
     rainbow (3.1.1)
     rdoc (6.6.2)
       psych (>= 4.0.0)
-    regexp_parser (2.8.3)
+    regexp_parser (2.9.0)
     reline (0.4.2)
       io-console (~> 0.5)
     rexml (3.2.6)
@@ -106,11 +106,11 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.1)
-    rubocop (1.59.0)
+    rubocop (1.60.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.2.4)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
@@ -121,8 +121,8 @@ GEM
       parser (>= 3.2.1.0)
     rubocop-capybara (2.20.0)
       rubocop (~> 1.41)
-    rubocop-factory_bot (2.25.0)
-      rubocop (~> 1.33)
+    rubocop-factory_bot (2.25.1)
+      rubocop (~> 1.41)
     rubocop-performance (1.20.2)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.30.0, < 2.0)

--- a/lib/capybara_accessible_selectors/filters/aria.rb
+++ b/lib/capybara_accessible_selectors/filters/aria.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Capybara::Selector::FilterSet[:capybara_accessible_selectors].instance_eval do
-  expression_filter(:aria, Hash, skip_if: nil) do |scope, nested_attributes|
+  expression_filter(:aria, valid_values: [Hash], skip_if: nil) do |scope, nested_attributes|
     prefixed_attributes = nested_attributes.transform_keys { |key| "aria-#{key}" }
 
     case scope

--- a/lib/capybara_accessible_selectors/filters/current.rb
+++ b/lib/capybara_accessible_selectors/filters/current.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Capybara::Selector::FilterSet[:capybara_accessible_selectors].instance_eval do
-  expression_filter(:current) do |xpath, value|
+  expression_filter(:current, valid_values: [nil, String]) do |xpath, value|
     value = value.nil? ? false : value.to_s
 
     builder(xpath).add_attribute_conditions("aria-current": value)

--- a/lib/capybara_accessible_selectors/filters/described_by.rb
+++ b/lib/capybara_accessible_selectors/filters/described_by.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Capybara::Selector::FilterSet[:capybara_accessible_selectors].instance_eval do
-  node_filter(:described_by, valid_values: String) do |node, value|
+  node_filter(:described_by, valid_values: [String]) do |node, value|
     next false unless node[:"aria-describedby"]
 
     description = CapybaraAccessibleSelectors::Helpers.element_describedby(node)

--- a/lib/capybara_accessible_selectors/filters/required.rb
+++ b/lib/capybara_accessible_selectors/filters/required.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Capybara::Selector::FilterSet[:capybara_accessible_selectors].instance_eval do
-  expression_filter(:required, skip_if: nil) do |xpath, value|
+  expression_filter(:required, :boolean, skip_if: nil) do |xpath, value|
     next xpath[XPath.attr(:required) | XPath.attr(:"aria-required") == "true"] if value
 
     xpath[~XPath.attr(:required) & (~(XPath.attr(:"aria-required") == "true"))]

--- a/lib/capybara_accessible_selectors/filters/role.rb
+++ b/lib/capybara_accessible_selectors/filters/role.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Capybara::Selector::FilterSet[:capybara_accessible_selectors].instance_eval do
-  expression_filter(:role, skip_if: nil) do |scope, value|
+  expression_filter(:role, valid_values: [String, Symbol], skip_if: nil) do |scope, value|
     case scope
     when String then %(#{scope}[role="#{value}"])
     else             scope[XPath.attr(:role) == value.to_s]

--- a/lib/capybara_accessible_selectors/selectors/combo_box.rb
+++ b/lib/capybara_accessible_selectors/selectors/combo_box.rb
@@ -17,7 +17,7 @@ Capybara.add_selector(:combo_box, locator_type: [String, Symbol]) do
   filter_set(:capybara_accessible_selectors, %i[aria fieldset described_by validation_error required])
 
   # with a value
-  node_filter(:with) do |node, with|
+  node_filter(:with, valid_values: [String, Regexp, Symbol]) do |node, with|
     val = node.value
     (with.is_a?(Regexp) ? with.match?(val) : val == with.to_s).tap do |res|
       add_error("Expected value to be #{with.inspect} but was #{val.inspect}") unless res
@@ -37,7 +37,7 @@ Capybara.add_selector(:combo_box, locator_type: [String, Symbol]) do
   end
 
   # with exact options
-  node_filter(:options) do |node, options|
+  node_filter(:options, valid_values: [Array, String, Regexp]) do |node, options|
     options = Array(options)
     actual = options_text(node, expression_for(:list_box_option, nil))
     match_all_options?(actual, options).tap do |res|
@@ -46,7 +46,7 @@ Capybara.add_selector(:combo_box, locator_type: [String, Symbol]) do
   end
 
   # with parital options
-  node_filter(:with_options) do |node, options|
+  node_filter(:with_options, valid_values: [Array, String, Regexp]) do |node, options|
     options = Array(options)
     actual = options_text(node, expression_for(:list_box_option, nil))
     match_some_options?(actual, options).tap do |res|
@@ -55,7 +55,7 @@ Capybara.add_selector(:combo_box, locator_type: [String, Symbol]) do
   end
 
   # with exact enabled options
-  node_filter(:enabled_options) do |node, options|
+  node_filter(:enabled_options, valid_values: [Array, String, Regexp]) do |node, options|
     options = Array(options)
     actual = options_text(node, expression_for(:list_box_option, nil)) { |n| n["aria-disabled"] != "true" }
     match_all_options?(actual, options).tap do |res|
@@ -64,7 +64,7 @@ Capybara.add_selector(:combo_box, locator_type: [String, Symbol]) do
   end
 
   # with exact enabled options
-  node_filter(:with_enabled_options) do |node, options|
+  node_filter(:with_enabled_options, valid_values: [Array, String, Regexp]) do |node, options|
     options = Array(options)
     actual = options_text(node, expression_for(:list_box_option, nil)) { |n| n["aria-disabled"] != "true" }
     match_some_options?(actual, options).tap do |res|
@@ -73,7 +73,7 @@ Capybara.add_selector(:combo_box, locator_type: [String, Symbol]) do
   end
 
   # with exact disabled options
-  node_filter(:disabled_options) do |node, options|
+  node_filter(:disabled_options, valid_values: [Array, String, Regexp]) do |node, options|
     options = Array(options)
     actual = options_text(node, expression_for(:list_box_option, nil)) { |n| n["aria-disabled"] == "true" }
     match_all_options?(actual, options).tap do |res|
@@ -82,7 +82,7 @@ Capybara.add_selector(:combo_box, locator_type: [String, Symbol]) do
   end
 
   # with exact enabled options
-  node_filter(:with_disabled_options) do |node, options|
+  node_filter(:with_disabled_options, valid_values: [Array, String, Regexp]) do |node, options|
     options = Array(options)
     actual = options_text(node, expression_for(:list_box_option, nil)) { |n| n["aria-disabled"] == "true" }
     match_some_options?(actual, options).tap do |res|

--- a/lib/capybara_accessible_selectors/selectors/grid.rb
+++ b/lib/capybara_accessible_selectors/selectors/grid.rb
@@ -14,7 +14,7 @@ Capybara.add_selector(:grid, locator_type: [String, Symbol]) do
     end
   end
 
-  node_filter(:described_by, valid_values: String) do |node, value|
+  node_filter(:described_by, valid_values: [String]) do |node, value|
     if node.tag_name == "table" && node.has_css?("caption") && (caption = node.find("caption")) && caption.text.include?(value)
       true
     else
@@ -40,7 +40,7 @@ Capybara.add_selector(:columnheader, locator_type: [String, Symbol]) do
     end
   end
 
-  expression_filter(:colindex, [Integer, String], skip_if: nil) do |xpath, value|
+  expression_filter(:colindex, valid_values: [Integer, String], skip_if: nil) do |xpath, value|
     colindex = XPath.attr(:"aria-colindex") == value.to_s
     position = (!XPath.attr(:"aria-colindex")) & (XPath.local_name == "th") & (XPath.position == value.to_i - 1)
 
@@ -61,7 +61,7 @@ Capybara.add_selector(:gridcell, locator_type: [String, Symbol]) do
     end
   end
 
-  expression_filter(:colindex, [Integer, String], skip_if: nil) do |xpath, value|
+  expression_filter(:colindex, valid_values: [Integer, String], skip_if: nil) do |xpath, value|
     row_ancestor = XPath.ancestor[(XPath.attr(:role) == "row") | (XPath.local_name == "tr")]
     colindex = row_ancestor & (XPath.attr(:"aria-colindex") == value.to_s)
     position = row_ancestor & (!XPath.attr(:"aria-colindex")) & (XPath.position == value.to_i)
@@ -69,7 +69,7 @@ Capybara.add_selector(:gridcell, locator_type: [String, Symbol]) do
     xpath[colindex | position]
   end
 
-  node_filter(:rowindex, [Integer, String], skip_if: nil) do |gridcell, value|
+  node_filter(:rowindex, valid_values: [Integer, String], skip_if: nil) do |gridcell, value|
     if gridcell.has_ancestor?(:row)
       row = gridcell.ancestor(:row)
 
@@ -85,7 +85,7 @@ Capybara.add_selector(:gridcell, locator_type: [String, Symbol]) do
     end
   end
 
-  node_filter(:columnheader, [String, Symbol], skip_if: nil) do |node, value|
+  node_filter(:columnheader, valid_values: [String, Symbol], skip_if: nil) do |node, value|
     colindex = node[:"aria-colindex"] || node.ancestor(:row).all(:gridcell).index(node)
     grid = node.find(:xpath, XPath.ancestor[XPath.attr(:role) == "grid"])
 
@@ -107,7 +107,7 @@ Capybara.add_selector(:row, locator_type: [String, Symbol]) do
     end
   end
 
-  node_filter(:rowindex, [Integer, String], skip_if: nil) do |row, value|
+  node_filter(:rowindex, valid_values: [Integer, String], skip_if: nil) do |row, value|
     case row[:"aria-rowindex"]
     when value.to_s then true
     when NilClass

--- a/lib/capybara_accessible_selectors/selectors/img.rb
+++ b/lib/capybara_accessible_selectors/selectors/img.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Capybara.add_selector(:img, locator_type: [String, Symbol]) do
-  expression_filter(:src, [String, Regexp]) do |xpath, src|
+  expression_filter(:src, valid_values: [String, Regexp]) do |xpath, src|
     builder(xpath).add_attribute_conditions(src: src)
   end
 

--- a/lib/capybara_accessible_selectors/selectors/menu.rb
+++ b/lib/capybara_accessible_selectors/selectors/menu.rb
@@ -23,7 +23,7 @@ Capybara.add_selector(:menu, locator_type: [String, Symbol]) do
     xpath[button.attr(:"aria-controls") == XPath.attr(:id)]
   end
 
-  node_filter(:orientation, [String, Symbol]) do |node, value|
+  node_filter(:orientation, valid_values: [String, Symbol]) do |node, value|
     orientation = (node[:"aria-orientation"] || "vertical").to_s
 
     orientation == value.to_s

--- a/lib/capybara_accessible_selectors/selectors/rich_text.rb
+++ b/lib/capybara_accessible_selectors/selectors/rich_text.rb
@@ -25,6 +25,8 @@ Capybara.add_selector(:rich_text, locator_type: [String, Symbol, Array]) do
   end
 end
 
+# rubocop:disable Style/ArgumentsForwarding
+
 module CapybaraAccessibleSelectors
   module Actions
     # Fill in a rich text area with text
@@ -92,3 +94,5 @@ module CapybaraAccessibleSelectors
     end
   end
 end
+
+# rubocop:enable Style/ArgumentsForwarding

--- a/spec/selectors/img_spec.rb
+++ b/spec/selectors/img_spec.rb
@@ -22,7 +22,7 @@ describe "img selector" do
 
   it "does not find exact aria-label with the wrong text" do
     expect do
-      find(:img, "aria-labe", exact: true)
+      find(:img, "aria-labe", exact: true, wait: false)
     end.to raise_error Capybara::ElementNotFound
   end
 
@@ -43,7 +43,7 @@ describe "img selector" do
 
   it "does not find by exact aria-labelledby with the wrong text" do
     expect do
-      find(:img, "split la", exact: true)
+      find(:img, "split la", exact: true, wait: false)
     end.to raise_error Capybara::ElementNotFound
   end
 
@@ -69,7 +69,7 @@ describe "img selector" do
 
   it "does not find exact alt with the wrong text" do
     expect do
-      find(:img, "alt tex", exact: true)
+      find(:img, "alt tex", exact: true, wait: false)
     end.to raise_error Capybara::ElementNotFound
   end
 


### PR DESCRIPTION
Adds more consistent handling of filter types.

All node and expression filters now have `valid_values`, which are added as arrays, or using the `:boolean` shortcut.