### PR TITLE
allow regexp for descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix `:section` selector matching sections with no headings
 - `:section` selector will also match aria headings
 - Selector filters will now validate their values more strictly
+- `described_by` and `validation_error` will also accept a regular expression
 
 ## v0.10.0
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ values. A `current: true` will match against `[aria-current="true"]`, and a
 `current: false` will match against `[aria-current="false"]`. To match an
 element **without any** `[aria-current]` attribute, pass `current: nil`.
 
-#### `described_by` [String]
+#### `described_by` [String, Regexp]
 
 Added to all selectors.
 
@@ -196,7 +196,7 @@ Filters for an element that declares a matching [role](https://www.w3.org/TR/wai
 expect(page).to have_field "A switch input", role: "switch"
 ```
 
-#### `validation_error` [String, true, false]
+#### `validation_error` [String, Regexp, true, false]
 
 Added to: `field`, `fillable_field`, `datalist_input`, `radio_button`, `checkbox`, `select`, `file_field`, `combo_box` and `rich_text`.
 

--- a/lib/capybara_accessible_selectors/filters/described_by.rb
+++ b/lib/capybara_accessible_selectors/filters/described_by.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 Capybara::Selector::FilterSet[:capybara_accessible_selectors].instance_eval do
-  node_filter(:described_by, valid_values: [String]) do |node, value|
+  node_filter(:described_by, valid_values: [String, Regexp]) do |node, value|
     next false unless node[:"aria-describedby"]
 
     description = CapybaraAccessibleSelectors::Helpers.element_describedby(node)
-    next true if description.include? value
+    next true if value.is_a?(String) && description.include?(value)
+    next true if value.is_a?(Regexp) && value.match?(description)
 
-    add_error " expected to be described by \"#{value}\" but it was described by \"#{description}\"."
+    add_error " expected to be described by #{value.inspect} but it was described by \"#{description}\"."
     false
   end
 end

--- a/spec/filters/described_by_spec.rb
+++ b/spec/filters/described_by_spec.rb
@@ -64,4 +64,17 @@ describe "described by filter" do
     end.to raise_error RSpec::Expectations::ExpectationNotMetError,
                        /expected to be described by "foo" but it was described by "Text description"/
   end
+
+  context "with a regular expression" do
+    it "filters a field" do
+      expect(page).to have_selector :field, "Text", described_by: /description/
+    end
+
+    it "provides a friendly error" do
+      expect do
+        expect(page).to have_selector :field, "Text", described_by: /foo/, wait: false
+      end.to raise_error RSpec::Expectations::ExpectationNotMetError,
+                         %r{expected to be described by /foo/ but it was described by "Text description"}
+    end
+  end
 end

--- a/spec/filters/validation_error_spec.rb
+++ b/spec/filters/validation_error_spec.rb
@@ -221,4 +221,25 @@ describe "validation error filter" do
       end.to raise_error RSpec::Expectations::ExpectationNotMetError, /expected element to have aria-invalid=true/
     end
   end
+
+  context "with a regular expression" do
+    it "selects an invalid field" do
+      render <<~HTML
+        <label>Text<input aria-describedby="id" required></label>
+        <span id="id">Text error</span>
+      HTML
+      expect(page).to have_selector :field, "Text", validation_error: /error/
+    end
+
+    it "provides a friendly error" do
+      render <<~HTML
+        <label>Text<input aria-describedby="id" required></label>
+        <span id="id">Text error</span>
+      HTML
+      expect do
+        expect(page).to have_selector :field, "Text", validation_error: /foo/, wait: false
+      end.to raise_error RSpec::Expectations::ExpectationNotMetError,
+                         %r{expected to be described by /foo/ but it was described by "Text Text error"}
+    end
+  end
 end


### PR DESCRIPTION
Allows `described_by` and `validation_error` to use regular expressions