### PR TITLE
`:rich_text`: support `[contenteditable=""]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Change `:rich_text` to support both `[contenteditable="true"]` and `[contenteditable=""]` [Sean Doyle]
 - Add `img` selector and matcher
 - Added `aria` filter to `:combo_box`, `:disclosure`, and `:disclosure_button` [Sean Doyle]
 - Removed support for Ruby 2.7. Minimum supported Ruby version is now 3.0

--- a/README.md
+++ b/README.md
@@ -669,7 +669,7 @@ Also see:
 
 Finds a rich text editor.
 
-This should be compatible with most browser based rich text editors. It searches for `contenteditable` section marked up with the correct role. It is also compatible with `<iframe>` based editors such as CKEditor 4 and TinyMCE.
+This should be compatible with most browser based rich text editors. It searches for an element with the [`contenteditable` attribute][] marked up with the [`textbox` role][]. It is also compatible with `<iframe>` based editors such as CKEditor 4 and TinyMCE.
 
 - `locator` [String, Symbol] The label for the editor. This can be an `aria-label` or `aria-labelledby`. For iframe editors this is the `title` attribute.
 
@@ -690,6 +690,9 @@ Also see:
 - [↓ `fill_in_rich_text` action](#fill_in_rich_textlocator-options)
 - [↓ Expectation shortcuts](#expectation-shortcuts)
 - [↓ `within_rich_text`](#within_rich_textname-find_options-block)
+
+[`contenteditable` attribute]: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable
+[`textbox` role]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/textbox_role
 
 #### `section`
 

--- a/lib/capybara_accessible_selectors/selectors/rich_text.rb
+++ b/lib/capybara_accessible_selectors/selectors/rich_text.rb
@@ -4,7 +4,7 @@ Capybara.add_selector(:rich_text, locator_type: [String, Symbol, Array]) do
   xpath do |locator, *|
     XPath.descendant[[
       XPath.attribute(:role) == "textbox",
-      XPath.attribute(:contenteditable) == "true"
+      ((XPath.attribute(:contenteditable) == "true") | (XPath.attribute(:contenteditable) == ""))
     ].reduce(:&)] + XPath.descendant(:iframe)[XPath.attr(:title).is(locator.to_s)]
   end
 

--- a/spec/fixtures/rich_text.html
+++ b/spec/fixtures/rich_text.html
@@ -3,7 +3,7 @@
   <meta charset="UTF-8">
   <title>Rich text</title>
   <style>
-    [contenteditable=true], iframe {
+    [contenteditable=true], [contenteditable=""], iframe {
       height: 100px;
       border: 1px solid #ddd;
       width: 100%;
@@ -33,6 +33,11 @@
   <div id="label-id-part2">aria-labelledby</div>
   <div id="label-id-part1">with</div>
   <div contenteditable="true" role="textbox" aria-labelledby="label-id-part1 label-id-part2" id="rt-aria-labelledby">
+  </div>
+
+  <h2>Empty content editable attribute</h2>
+
+  <div contenteditable role="textbox" aria-label="empty [contenteditable]" id="rt-empty-contenteditable">
   </div>
 
   <h2>Content editable iframe with title</h2>

--- a/spec/selectors/rich_text_spec.rb
+++ b/spec/selectors/rich_text_spec.rb
@@ -10,6 +10,11 @@ describe "rich text" do
         expect(page.find(:rich_text, "with label")).to eq rich_text
       end
 
+      it "finds a rich text area with empty [contenteditable]" do
+        rich_text = page.find(:id, "rt-empty-contenteditable")
+        expect(page.find(:rich_text, "empty [contenteditable]")).to eq rich_text
+      end
+
       it "finds a rich text area with a partial label" do
         rich_text = page.find(:id, "rt-aria-label")
         expect(page.find(:rich_text, "with la")).to eq rich_text


### PR DESCRIPTION
The [contenteditable] attribute behaves like a [boolean attribute][], in that its presence is equivalent to a `="true"` value. 

> * `true` or an empty string, which indicates that the element is editable.
> ...
> If the attribute is given without a value, like <label contenteditable>Example Label</label>, its value is treated as an empty string.
> 

It's different in that it supports disabling the value with `[contenteditable="false"]`:

> Note that although its allowed values include true and false, this attribute is an [enumerated](https://developer.mozilla.org/en-US/docs/Glossary/Enumerated) one and not a Boolean one.

This commit expands the `:rich_text` selector to support editors that set `[contenteditable]` (like Action Text's `<trix-editor>`).

[contenteditable]: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable
[boolean attribute]: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes#boolean_attributes