### PR TITLE
select_combo_box_option updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## Unreleased
+
+### Changed
+
+- Passing an empty string to `select_combo_box_option` will clear the combo-box
+- `select_combo_box_option` takes a block which can be used to filter the found options
+- `select_combo_box_option` will assert the list box has been closed after selecting an option
+
 ## v0.11.0
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.3)
+    activesupport (7.1.3.2)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -52,7 +52,7 @@ GEM
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
-    irb (1.11.1)
+    irb (1.11.2)
       rdoc
       reline (>= 0.4.2)
     json (2.7.1)
@@ -60,7 +60,7 @@ GEM
     matrix (0.4.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
-    minitest (5.22.0)
+    minitest (5.22.2)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     mutex_m (0.2.0)
@@ -80,7 +80,7 @@ GEM
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
-    rack (3.0.9)
+    rack (3.0.9.1)
     rack-protection (4.0.0)
       base64 (>= 0.1.0)
       rack (>= 3.0.0, < 4)
@@ -143,7 +143,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    selenium-webdriver (4.17.0)
+    selenium-webdriver (4.18.1)
       base64 (~> 0.2)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)

--- a/README.md
+++ b/README.md
@@ -788,7 +788,7 @@ Also see [↑ `tab_panel` selector](#tab_panel)
 
 Fill in a combo box and select an option
 
-- `with` [String] - Option to select
+- `with` [String] - Option to select, or an empty string to clear the combo box
 - `options`:
   - `from` [String, Symbol, Array] - Locator for the field
   - `search` [String] - Alternative text to search for in the input

--- a/spec/fixtures/combo_box.html
+++ b/spec/fixtures/combo_box.html
@@ -86,6 +86,25 @@
         target.parentNode.setAttribute('aria-expanded', 'true');
       }
     });
+
+    input.addEventListener('change', ({ target }) => {
+      if (target.value === "") {
+        listbox.querySelectorAll('[role=option],.tt-selectable').forEach((option) => {
+          option.removeAttribute('aria-selected');
+        });
+      }
+    });
+
+    input.addEventListener('keydown', ({ target, key }) => {
+      if (key === "Escape") {
+        target.nextElementSibling.hidden = true;
+        if (target.hasAttribute('aria-expanded')) {
+          target.setAttribute('aria-expanded', 'false');
+        } else if (target.parentNode.hasAttribute('aria-expanded')) {
+          target.parentNode.setAttribute('aria-expanded', 'false');
+        }
+      }
+    });
   });
   document.querySelectorAll('[role=listbox],.tt-menu').forEach((listbox) => {
     listbox.addEventListener('click', ({ target }) => {

--- a/spec/selectors/combo_box_spec.rb
+++ b/spec/selectors/combo_box_spec.rb
@@ -256,6 +256,19 @@ describe "combo_box selector" do
           expect(page).to have_selector :combo_box, label, with: "Orange"
         end
 
+        it "allows finding an option with a block" do
+          select_combo_box_option(from: label) { _1.text.include? "Orange" }
+          expect(page).to have_selector :combo_box, label, with: "Orange"
+        end
+
+        it "clears a current option with a string" do
+          select_combo_box_option "Orange", from: label
+          expect(page).to have_selector :combo_box, label, with: "Orange"
+          select_combo_box_option "", from: label
+          expect(page).to have_field label, with: ""
+          expect(page).to have_no_selector :combo_box_list_box, find(:combo_box, label)
+        end
+
         describe "currently_with" do
           it "fills in a combo box with an existing value" do
             select_combo_box_option "Banana", from: label
@@ -388,6 +401,19 @@ describe "combo_box selector" do
       it "allows finding an option with finder options" do
         select_combo_box_option from: label, option_match: :first, option_text: /orange/i
         expect(page).to have_selector :combo_box, label, with: "Orange"
+      end
+
+      it "allows finding an option with a block" do
+        select_combo_box_option(from: label) { _1.text.include? "Orange" }
+        expect(page).to have_selector :combo_box, label, with: "Orange"
+      end
+
+      it "clears a current option with a string" do
+        select_combo_box_option "Orange", from: label
+        expect(page).to have_selector :combo_box, label, with: "Orange"
+        select_combo_box_option "", from: label
+        expect(page).to have_field label, with: ""
+        expect(page).to have_no_selector :combo_box_list_box, find(:combo_box, label)
       end
 
       describe "currently_with" do


### PR DESCRIPTION
- Passing an empty string to `select_combo_box_option` will clear the combo-box
- `select_combo_box_option` takes a block which can be used to filter the found options
- `select_combo_box_option` will assert the list box has been closed after selecting an option