### PR TITLE
Fix `AccessibleNameFilter` description

### DIFF
--- a/lib/capybara_accessible_selectors/filters/accessible_name.rb
+++ b/lib/capybara_accessible_selectors/filters/accessible_name.rb
@@ -4,7 +4,7 @@ module CapybaraAccessibleSelectors
   # This is hacked into SelectorQuery to the "exact" option can be supported
 
   module AccessibleNameFilter
-    def description(_)
+    def description(*)
       desc = super
       desc << " with accessible name #{options[:accessible_name].inspect}" if options[:accessible_name]
       desc

--- a/spec/filters/accessible_name_spec.rb
+++ b/spec/filters/accessible_name_spec.rb
@@ -66,4 +66,18 @@ describe "accessible_name" do
       find :element, :section, accessible_name: "foo", wait: false
     end.to raise_error Capybara::ElementNotFound, /with accessible name "foo"/
   end
+
+  it "composes the error description with the sibling filter" do
+    render <<~HTML
+      <section>
+        <h1>Heading</h1>
+      </section>
+    HTML
+
+    section = find :element, :section
+
+    expect do
+      section.sibling :section, accessible_name: "foo", wait: false
+    end.to raise_error Capybara::ElementNotFound, /with accessible name "foo" that is a sibling/
+  end
 end


### PR DESCRIPTION
`AccessibleNameFilter` is not working well with some queries, such as `sibling` or `ancestor`. Those queries expect the `description` method to work without any arguments. Most Capybara filters work with an optional `applied` argument, while `AccessibleNameFilter` expects exactly one argument.

This commit changes the `description` method to accept any number of arguments by using the splat operator.