### PR TITLE
Implement `Capybara::Node::Simple#role`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Remove ruby 3.1 support. Minimum supported Ruby version is now 3.2
+- Extend `Capybara::Node::Simple` with the `role` attribute to support the
+  `:role` filter
 
 ## v0.12.0
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ This uses the Selenium driver `aria_role` method which uses the role calculated 
 into account [implicit role mappings](https://www.w3.org/TR/html-aria/). The results for implicit roles are
 not consistent across all browsers, but are good for more common use cases.
 
-Rack test will currently only use the value of the `role` attribute and does not return implicit role values.
+Assertions made against the output of [Caypbara.string][] or by tests driven by Rack Test will currently only use the value of the `role` attribute and does not return implicit role values.
 
 This method must request the role from the driver for each node found by the selector individually.
 Therefore, using this with a selector that returns a large number of elements will be inefficient.
@@ -232,6 +232,8 @@ Therefore, using this with a selector that returns a large number of elements wi
 ```ruby
 expect(page).to have_field "A switch input", role: "switch"
 ```
+
+[Capybara.string]: https://rubydoc.info/github/teamcapybara/capybara/master/Capybara#string-class_method
 
 #### `validation_error` [String, Regexp, true, false]
 

--- a/lib/capybara_accessible_selectors/node/role.rb
+++ b/lib/capybara_accessible_selectors/node/role.rb
@@ -43,4 +43,5 @@ module CapybaraAccessibleSelectors
   ::Capybara::Node::Element.include NodeElementExtensions
   ::Capybara::Selenium::Node.include SeleniumNodeExtensions
   ::Capybara::RackTest::Node.include RackTestNodeExtensions
+  ::Capybara::Node::Simple.include RackTestNodeExtensions
 end

--- a/spec/capybara/node/simple/role_spec.rb
+++ b/spec/capybara/node/simple/role_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe Capybara::Node::Simple, "#role" do
+  it "returns the value of an explicit role attribute" do
+    render <<~HTML
+      <div role="listbox">
+        <a role="option" href="http://example.com">
+          contents
+        </a>
+      </div>
+    HTML
+    expect(find(:element, "a").role).to eq "option"
+  end
+
+  it "returns no role as nil" do
+    render <<~HTML
+      <meta name="foo" contents="bar">
+    HTML
+    expect(find(:element, "meta", name: "foo", visible: false).role).to be_nil
+  end
+
+  private
+
+  attr_reader :page
+
+  def render(html)
+    @page = Capybara.string(html)
+  end
+end


### PR DESCRIPTION
Prior to this commit, instances of `Capybara::Node::Simple` (like those returned by [Capybara.string][]) do not implement the `#role` attribute that the `:role` filter implementation is dependent upon.

This commit mixes the pre-existing `RackTestNodeExtensions` into the [Capybara::Node::Simple][] class to support nodes created from static HTML.

[Capybara.string]: https://rubydoc.info/github/teamcapybara/capybara/master/Capybara#string-class_method
[Capybara::Node::Simple]: https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Node/Simple