### PR TITLE
fix test errors with select_combo_box_option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Remove ruby 3.1 support. Minimum supported Ruby version is now 3.2
+- Fix xpath query timeout errors when using the disclosure selector with pages with large elements with ids
+- Improve how the `select_combo_box_option` waits for the option to show
 
 ## v0.12.0
 

--- a/spec/fixtures/combo_box.html
+++ b/spec/fixtures/combo_box.html
@@ -32,6 +32,20 @@
   </div>
 </div>
 
+<h2>ARIA 1.2</h2>
+
+<div>
+  <label for="aria12">aria 1.2</label>
+  <input type="text" role="combobox" aria-controls="listbox-aria12" id="aria12" aria-expanded="false" />
+  <div role="listbox" id="listbox-aria12" hidden>
+    <div role="option">Apple</div>
+    <div role="option">Banana</div>
+    <div role="option" aria-disabled="true">Disabled</div>
+    <div role="option">Orange</div>
+    <div role="option">Blood orange</div>
+  </div>
+</div>
+
 <h2>Twitter</h2>
 
 <p>DEPRECATED: This is an old version of twitter typeahead</p>

--- a/spec/selectors/combo_box_spec.rb
+++ b/spec/selectors/combo_box_spec.rb
@@ -5,7 +5,7 @@ describe "combo_box selector" do
     visit "/combo_box.html"
   end
 
-  ["aria 1.0", "aria 1.1"].each do |label|
+  ["aria 1.0", "aria 1.1", "aria 1.2"].each do |label|
     context label do
       it "finds a combo box" do
         combo_box = find(:field, label)


### PR DESCRIPTION
Hopefully fixes the `select_combo_box_option` tests sometimes failing due to timing issues with when the JavaScript hides elements.

Also add explicit tests for the aria 1.2 combo-box.