### PR TITLE
release 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## Unreleased
+## v0.13.0
 
 - Remove ruby 3.1 support. Minimum supported Ruby version is now 3.2
 - Fix xpath query timeout errors when using the disclosure selector with pages with large elements with ids

--- a/lib/capybara_accessible_selectors/version.rb
+++ b/lib/capybara_accessible_selectors/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CapybaraAccessibleSelectors
-  VERSION = "0.11.0"
+  VERSION = "0.13.0"
 end


### PR DESCRIPTION
- Remove ruby 3.1 support. Minimum supported Ruby version is now 3.2
- Fix xpath query timeout errors when using the disclosure selector with pages with large elements with ids
- Improve how the `select_combo_box_option` waits for the option to show
