### PR TITLE
adjust landmark selector parent rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Change log
 
-- Extend `Capybara::Node::Simple` with the `role` attribute to support the
-  `:role` filter
+## Unreleased
+
+- Extend `Capybara::Node::Simple` with the `role` attribute to support the `:role` filter
+- `:main`, `:banner` and `:contentinfo` selectors no longer requires the element to be a direct child of `<body>`
+- `:banner` and `:contentinfo` selectors use rules from [ARIA in HTML](https://w3c.github.io/html-aria/) for implicit matching
+- `:main`, `:banner`, `:contentinfo`, and `:navigation` are now implemented as `descendant_or_self`
 
 ## v0.13.0
 

--- a/lib/capybara_accessible_selectors/selectors/banner.rb
+++ b/lib/capybara_accessible_selectors/selectors/banner.rb
@@ -2,12 +2,12 @@
 
 Capybara.add_selector :banner, locator_type: [String, Symbol] do
   xpath do |*|
-    banner = XPath.descendant[[
-      XPath.local_name == "header",
-      XPath.attr(:role) == "banner"
-    ].reduce(:|)]
-
-    banner[XPath.parent(:body)]
+    implicit = XPath.self(:header)[!XPath.ancestor[[
+      *%i[article aside main nav section].map { XPath.self(_1) },
+      *%w[article complimentary main navigation region].map { XPath.attr(:role) == _1 }
+    ].inject(:|)]]
+    explicit = XPath.attr(:role) == "banner"
+    XPath.descendant_or_self[implicit | explicit]
   end
 
   locator_filter skip_if: nil do |node, locator, exact:, **|

--- a/lib/capybara_accessible_selectors/selectors/contentinfo.rb
+++ b/lib/capybara_accessible_selectors/selectors/contentinfo.rb
@@ -2,12 +2,12 @@
 
 Capybara.add_selector :contentinfo, locator_type: [String, Symbol] do
   xpath do |*|
-    contentinfo = XPath.descendant[[
-      XPath.local_name == "footer",
-      XPath.attr(:role) == "contentinfo"
-    ].reduce(:|)]
-
-    contentinfo[XPath.parent(:body)]
+    implicit = XPath.self(:footer)[!XPath.ancestor[[
+      *%i[article aside main nav section].map { XPath.self(_1) },
+      *%w[article complimentary main navigation region].map { XPath.attr(:role) == _1 }
+    ].inject(:|)]]
+    explicit = XPath.attr(:role) == "contentinfo"
+    XPath.descendant_or_self[implicit | explicit]
   end
 
   locator_filter skip_if: nil do |node, locator, exact:, **|

--- a/lib/capybara_accessible_selectors/selectors/main.rb
+++ b/lib/capybara_accessible_selectors/selectors/main.rb
@@ -2,12 +2,10 @@
 
 Capybara.add_selector :main, locator_type: [String, Symbol] do
   xpath do |*|
-    main = XPath.descendant[[
+    XPath.descendant_or_self[[
       XPath.local_name == "main",
       XPath.attr(:role) == "main"
     ].reduce(:|)]
-
-    main[XPath.parent(:body)]
   end
 
   locator_filter skip_if: nil do |node, locator, exact:, **|

--- a/lib/capybara_accessible_selectors/selectors/navigation.rb
+++ b/lib/capybara_accessible_selectors/selectors/navigation.rb
@@ -2,7 +2,7 @@
 
 Capybara.add_selector :navigation, locator_type: [String, Symbol] do
   xpath do |*|
-    XPath.descendant[[
+    XPath.descendant_or_self[[
       XPath.local_name == "nav",
       XPath.attr(:role) == "navigation"
     ].reduce(:|)]

--- a/spec/selectors/banner_spec.rb
+++ b/spec/selectors/banner_spec.rb
@@ -3,166 +3,334 @@
 describe "banner selector" do
   describe "locator" do
     context "when <header> element" do
-      context "when direct descendant of body" do
-        it "finds the first element" do
-          render <<~HTML
-            <header>Content</header>
-          HTML
+      it "finds the first element" do
+        render <<~HTML
+          <header>Content</header>
+        HTML
 
+        expect(page).to have_selector :banner, count: 1
+      end
+
+      it "finds from self" do
+        render <<~HTML
+          <header>Content</header>
+        HTML
+
+        within :css, "header" do
           expect(page).to have_selector :banner, count: 1
-        end
-
-        it "finds based on [aria-label]" do
-          render <<~HTML
-            <header aria-label="Header banner">Content</header>
-          HTML
-
-          expect(page).to have_selector :banner, "Header banner"
-        end
-
-        it "does not find differing on [aria-label]" do
-          render <<~HTML
-            <header aria-label="Header banner">Content</header>
-          HTML
-
-          expect(page).to have_no_selector :banner, "Not the right locator"
-        end
-
-        it "finds based on [aria-labelledby]" do
-          render <<~HTML
-            <header aria-labelledby="banner_label">
-              <h1 id="banner_label">Header banner</h1>
-            </header>
-          HTML
-
-          expect(page).to have_selector :banner, "Header banner"
-        end
-
-        it "does not find differing on [aria-labelledby]" do
-          render <<~HTML
-            <header aria-labelledby="banner_label">
-              <h1 id="banner_label">Header banner</h1>
-            </header>
-          HTML
-
-          expect(page).to have_no_selector :banner, "Not the right locator"
         end
       end
 
-      context "when descendant of another element" do
-        it "does not find any elements" do
-          html = %w[article aside main nav section].map do |element|
-            "<#{element}><header>Content</header></#{element}>"
-          end.join
+      it "finds based on [aria-label]" do
+        render <<~HTML
+          <header aria-label="Header banner">Content</header>
+        HTML
 
-          render html
+        expect(page).to have_selector :banner, "Header banner"
+      end
 
-          expect(page).to have_no_selector :banner
-        end
+      it "does not find differing on [aria-label]" do
+        render <<~HTML
+          <header aria-label="Header banner">Content</header>
+        HTML
 
-        it "does not find based on [aria-label]" do
-          render <<~HTML
-            <section>
-              <header aria-label="Header banner">Content</header>
-            </section>
-          HTML
+        expect(page).to have_no_selector :banner, "Not the right locator"
+      end
 
-          expect(page).to have_no_selector :banner, "Header banner"
-        end
+      it "finds based on [aria-labelledby]" do
+        render <<~HTML
+          <header aria-labelledby="banner_label">
+            <h1 id="banner_label">Header banner</h1>
+          </header>
+        HTML
 
-        it "does not find based on [aria-labelledby]" do
-          render <<~HTML
-            <section>
-              <header aria-labelledby="banner_label">
-                <h1 id="banner_label">Header banner</h1>
-              </header>
-            </section>
-          HTML
+        expect(page).to have_selector :banner, "Header banner"
+      end
 
-          expect(page).to have_no_selector :banner, "Header banner"
-        end
+      it "does not find differing on [aria-labelledby]" do
+        render <<~HTML
+          <header aria-labelledby="banner_label">
+            <h1 id="banner_label">Header banner</h1>
+          </header>
+        HTML
+
+        expect(page).to have_no_selector :banner, "Not the right locator"
+      end
+
+      it "does find if a child of a div" do
+        render <<~HTML
+          <div>
+            <header>Content</header>
+          </div>
+        HTML
+
+        expect(page).to have_selector :banner
+      end
+
+      it "does not find if a child of an article" do
+        render <<~HTML
+          <article>
+            <header>Content</header>
+          </article>
+        HTML
+
+        expect(page).to have_no_selector :banner, "Wrong ancestor"
+      end
+
+      it "does not find if a child of an aside" do
+        render <<~HTML
+          <aside>
+            <header>Content</header>
+          </aside>
+        HTML
+
+        expect(page).to have_no_selector :banner, "Wrong ancestor"
+      end
+
+      it "does not find if a child of a main" do
+        render <<~HTML
+          <main>
+            <header>Content</header>
+          </main>
+        HTML
+
+        expect(page).to have_no_selector :banner, "Wrong ancestor"
+      end
+
+      it "does not find if a child of a nav" do
+        render <<~HTML
+          <nav>
+            <header>Content</header>
+          </nav>
+        HTML
+
+        expect(page).to have_no_selector :banner, "Wrong ancestor"
+      end
+
+      it "does not find if a child of a section" do
+        render <<~HTML
+          <section>
+            <header>Content</header>
+          </section>
+        HTML
+
+        expect(page).to have_no_selector :banner, "Wrong ancestor"
+      end
+
+      it "does find if a child of a group" do
+        render <<~HTML
+          <div role="group">
+            <header>Content</header>
+          </div>
+        HTML
+
+        expect(page).to have_selector :banner
+      end
+
+      it "does not find if a child of an explicit role article" do
+        render <<~HTML
+          <div role="article">
+            <header>Content</header>
+          </div>
+        HTML
+
+        expect(page).to have_no_selector :banner, "Wrong ancestor"
+      end
+
+      it "does not find if a child of an explicit role complimentary" do
+        render <<~HTML
+          <div role="complimentary">
+            <header>Content</header>
+          </div>
+        HTML
+
+        expect(page).to have_no_selector :banner, "Wrong ancestor"
+      end
+
+      it "does not find if a child of an explicit role main" do
+        render <<~HTML
+          <div role="main">
+            <header>Content</header>
+          </div>
+        HTML
+
+        expect(page).to have_no_selector :banner, "Wrong ancestor"
+      end
+
+      it "does not find if a child of an explicit role navigation" do
+        render <<~HTML
+          <div role="navigation">
+            <header>Content</header>
+          </div>
+        HTML
+
+        expect(page).to have_no_selector :banner, "Wrong ancestor"
+      end
+
+      it "does not find if a child of an explicit role region" do
+        render <<~HTML
+          <div role="region">
+            <header>Content</header>
+          </div>
+        HTML
+
+        expect(page).to have_no_selector :banner, "Wrong ancestor"
       end
     end
 
     context "when [role=banner]" do
-      context "when direct descendant of body" do
-        it "finds the first element" do
-          render <<~HTML
-            <div role="banner">Content</div>
-          HTML
+      it "finds the first element" do
+        render <<~HTML
+          <div role="banner">Content</div>
+        HTML
 
+        expect(page).to have_selector :banner, count: 1
+      end
+
+      it "finds from self" do
+        render <<~HTML
+          <div role="banner">Content</div>
+        HTML
+
+        within :css, "[role=banner]" do
           expect(page).to have_selector :banner, count: 1
-        end
-
-        it "finds based on [aria-label]" do
-          render <<~HTML
-            <div role="banner" aria-label="Header banner">Content</div>
-          HTML
-
-          expect(page).to have_selector :banner, "Header banner"
-        end
-
-        it "does not find differing on [aria-label]" do
-          render <<~HTML
-            <div role="banner" aria-label="Header banner">Content</div>
-          HTML
-
-          expect(page).to have_no_selector :banner, "Not the right locator"
-        end
-
-        it "finds based on [aria-labelledby]" do
-          render <<~HTML
-            <div role="banner" aria-labelledby="banner_label">
-              <h1 id="banner_label">Header banner</h1>
-            </div>
-          HTML
-
-          expect(page).to have_selector :banner, "Header banner"
-        end
-
-        it "does not find differing on [aria-labelledby]" do
-          render <<~HTML
-            <div role="banner" aria-labelledby="banner_label">
-              <h1 id="banner_label">Header banner</h1>
-            </div>
-          HTML
-
-          expect(page).to have_no_selector :banner, "Not the right locator"
         end
       end
 
-      context "when descendant of another element" do
-        it "does not find any elements" do
-          html = %w[article aside main nav section].map do |element|
-            %(<#{element}><div role="banner">Content</div></#{element}>)
-          end.join
+      it "finds based on [aria-label]" do
+        render <<~HTML
+          <div role="banner" aria-label="Header banner">Content</div>
+        HTML
 
-          render html
+        expect(page).to have_selector :banner, "Header banner"
+      end
 
-          expect(page).to have_no_selector :banner
-        end
+      it "does not find differing on [aria-label]" do
+        render <<~HTML
+          <div role="banner" aria-label="Header banner">Content</div>
+        HTML
 
-        it "does not find based on [aria-label]" do
-          render <<~HTML
-            <section>
-              <div role="banner" aria-label="Header banner">Content</div>
-            </section>
-          HTML
+        expect(page).to have_no_selector :banner, "Not the right locator"
+      end
 
-          expect(page).to have_no_selector :banner, "Header banner"
-        end
+      it "finds based on [aria-labelledby]" do
+        render <<~HTML
+          <div role="banner" aria-labelledby="banner_label">
+            <h1 id="banner_label">Header banner</h1>
+          </div>
+        HTML
 
-        it "does not find based on [aria-labelledby]" do
-          render <<~HTML
-            <section>
-              <div role="banner" aria-labelledby="banner_label">
-                <h1 id="banner_label">Header banner</h1>
-              </div>
-            </section>
-          HTML
+        expect(page).to have_selector :banner, "Header banner"
+      end
 
-          expect(page).to have_no_selector :banner, "Header banner"
-        end
+      it "does not find differing on [aria-labelledby]" do
+        render <<~HTML
+          <div role="banner" aria-labelledby="banner_label">
+            <h1 id="banner_label">Header banner</h1>
+          </div>
+        HTML
+
+        expect(page).to have_no_selector :banner, "Not the right locator"
+      end
+
+      it "does find if a child of an article" do
+        render <<~HTML
+          <article>
+            <div role="banner">Content</div>
+          </article>
+        HTML
+
+        expect(page).to have_selector :banner
+      end
+
+      it "does find if a child of an aside" do
+        render <<~HTML
+          <aside>
+            <div role="banner">Content</div>
+          </aside>
+        HTML
+
+        expect(page).to have_selector :banner
+      end
+
+      it "does find if a child of a main" do
+        render <<~HTML
+          <main>
+            <div role="banner">Content</div>
+          </main>
+        HTML
+
+        expect(page).to have_selector :banner
+      end
+
+      it "does find if a child of a nav" do
+        render <<~HTML
+          <nav>
+            <div role="banner">Content</div>
+          </nav>
+        HTML
+
+        expect(page).to have_selector :banner
+      end
+
+      it "does find if a child of a section" do
+        render <<~HTML
+          <section>
+            <div role="banner">Content</div>
+          </section>
+        HTML
+
+        expect(page).to have_selector :banner
+      end
+
+      it "does find if a child of an explicit role article" do
+        render <<~HTML
+          <div role="article">
+            <div role="banner">Content</div>
+          </div>
+        HTML
+
+        expect(page).to have_selector :banner
+      end
+
+      it "does find if a child of an explicit role complimentary" do
+        render <<~HTML
+          <div role="complimentary">
+            <div role="banner">Content</div>
+          </div>
+        HTML
+
+        expect(page).to have_selector :banner
+      end
+
+      it "does find if a child of an explicit role main" do
+        render <<~HTML
+          <div role="main">
+            <div role="banner">Content</div>
+          </div>
+        HTML
+
+        expect(page).to have_selector :banner
+      end
+
+      it "does find if a child of an explicit role navigation" do
+        render <<~HTML
+          <div role="navigation">
+            <div role="banner">Content</div>
+          </div>
+        HTML
+
+        expect(page).to have_selector :banner
+      end
+
+      it "does find if a child of an explicit role region" do
+        render <<~HTML
+          <div role="region">
+            <div role="banner">Content</div>
+          </div>
+        HTML
+
+        expect(page).to have_selector :banner
       end
     end
   end

--- a/spec/selectors/contentinfo_spec.rb
+++ b/spec/selectors/contentinfo_spec.rb
@@ -3,166 +3,334 @@
 describe "contentinfo selector" do
   describe "locator" do
     context "when <footer> element" do
-      context "when direct descendant of body" do
-        it "finds the first element" do
-          render <<~HTML
-            <footer>Content</footer>
-          HTML
+      it "finds the first element" do
+        render <<~HTML
+          <footer>Content</footer>
+        HTML
 
+        expect(page).to have_selector :contentinfo, count: 1
+      end
+
+      it "finds from self" do
+        render <<~HTML
+          <footer>Content</footer>
+        HTML
+
+        within :css, "footer" do
           expect(page).to have_selector :contentinfo, count: 1
-        end
-
-        it "finds based on [aria-label]" do
-          render <<~HTML
-            <footer aria-label="Footer contentinfo">Content</footer>
-          HTML
-
-          expect(page).to have_selector :contentinfo, "Footer contentinfo"
-        end
-
-        it "does not find differing on [aria-label]" do
-          render <<~HTML
-            <footer aria-label="Footer contentinfo">Content</footer>
-          HTML
-
-          expect(page).to have_no_selector :contentinfo, "Not the right locator"
-        end
-
-        it "finds based on [aria-labelledby]" do
-          render <<~HTML
-            <footer aria-labelledby="contentinfo_label">
-              <h1 id="contentinfo_label">Footer contentinfo</h1>
-            </footer>
-          HTML
-
-          expect(page).to have_selector :contentinfo, "Footer contentinfo"
-        end
-
-        it "does not find differing on [aria-labelledby]" do
-          render <<~HTML
-            <footer aria-labelledby="contentinfo_label">
-              <h1 id="contentinfo_label">Footer contentinfo</h1>
-            </footer>
-          HTML
-
-          expect(page).to have_no_selector :contentinfo, "Not the right locator"
         end
       end
 
-      context "when descendant of another element" do
-        it "does not find any elements" do
-          html = %w[article aside main nav section].map do |element|
-            "<#{element}><footer>Content</footer></#{element}>"
-          end.join
+      it "finds based on [aria-label]" do
+        render <<~HTML
+          <footer aria-label="Footer contentinfo">Content</footer>
+        HTML
 
-          render html
+        expect(page).to have_selector :contentinfo, "Footer contentinfo"
+      end
 
-          expect(page).to have_no_selector :contentinfo
-        end
+      it "does not find differing on [aria-label]" do
+        render <<~HTML
+          <footer aria-label="Footer contentinfo">Content</footer>
+        HTML
 
-        it "does not find based on [aria-label]" do
-          render <<~HTML
-            <section>
-              <footer aria-label="Footer contentinfo">Content</footer>
-            </section>
-          HTML
+        expect(page).to have_no_selector :contentinfo, "Not the right locator"
+      end
 
-          expect(page).to have_no_selector :contentinfo, "Footer contentinfo"
-        end
+      it "finds based on [aria-labelledby]" do
+        render <<~HTML
+          <footer aria-labelledby="contentinfo_label">
+            <h1 id="contentinfo_label">Footer contentinfo</h1>
+          </footer>
+        HTML
 
-        it "does not find based on [aria-labelledby]" do
-          render <<~HTML
-            <section>
-              <footer aria-labelledby="contentinfo_label">
-                <h1 id="contentinfo_label">Footer contentinfo</h1>
-              </footer>
-            </section>
-          HTML
+        expect(page).to have_selector :contentinfo, "Footer contentinfo"
+      end
 
-          expect(page).to have_no_selector :contentinfo, "Footer contentinfo"
-        end
+      it "does not find differing on [aria-labelledby]" do
+        render <<~HTML
+          <footer aria-labelledby="contentinfo_label">
+            <h1 id="contentinfo_label">Footer contentinfo</h1>
+          </footer>
+        HTML
+
+        expect(page).to have_no_selector :contentinfo, "Not the right locator"
+      end
+
+      it "does find if a child of a div" do
+        render <<~HTML
+          <div>
+            <footer>Content</footer>
+          </div>
+        HTML
+
+        expect(page).to have_selector :contentinfo
+      end
+
+      it "does not find if a child of an article" do
+        render <<~HTML
+          <article>
+            <footer>Content</footer>
+          </article>
+        HTML
+
+        expect(page).to have_no_selector :contentinfo, "Wrong ancestor"
+      end
+
+      it "does not find if a child of an aside" do
+        render <<~HTML
+          <aside>
+            <footer>Content</footer>
+          </aside>
+        HTML
+
+        expect(page).to have_no_selector :contentinfo, "Wrong ancestor"
+      end
+
+      it "does not find if a child of a main" do
+        render <<~HTML
+          <main>
+            <footer>Content</footer>
+          </main>
+        HTML
+
+        expect(page).to have_no_selector :contentinfo, "Wrong ancestor"
+      end
+
+      it "does not find if a child of a nav" do
+        render <<~HTML
+          <nav>
+            <footer>Content</footer>
+          </nav>
+        HTML
+
+        expect(page).to have_no_selector :contentinfo, "Wrong ancestor"
+      end
+
+      it "does not find if a child of a section" do
+        render <<~HTML
+          <section>
+            <footer>Content</footer>
+          </section>
+        HTML
+
+        expect(page).to have_no_selector :contentinfo, "Wrong ancestor"
+      end
+
+      it "does find if a child of a group" do
+        render <<~HTML
+          <div role="group">
+            <footer>Content</footer>
+          </div>
+        HTML
+
+        expect(page).to have_selector :contentinfo
+      end
+
+      it "does not find if a child of an explicit role article" do
+        render <<~HTML
+          <div role="article">
+            <footer>Content</footer>
+          </div>
+        HTML
+
+        expect(page).to have_no_selector :contentinfo, "Wrong ancestor"
+      end
+
+      it "does not find if a child of an explicit role complimentary" do
+        render <<~HTML
+          <div role="complimentary">
+            <footer>Content</footer>
+          </div>
+        HTML
+
+        expect(page).to have_no_selector :contentinfo, "Wrong ancestor"
+      end
+
+      it "does not find if a child of an explicit role main" do
+        render <<~HTML
+          <div role="main">
+            <footer>Content</footer>
+          </div>
+        HTML
+
+        expect(page).to have_no_selector :contentinfo, "Wrong ancestor"
+      end
+
+      it "does not find if a child of an explicit role navigation" do
+        render <<~HTML
+          <div role="navigation">
+            <footer>Content</footer>
+          </div>
+        HTML
+
+        expect(page).to have_no_selector :contentinfo, "Wrong ancestor"
+      end
+
+      it "does not find if a child of an explicit role region" do
+        render <<~HTML
+          <div role="region">
+            <footer>Content</footer>
+          </div>
+        HTML
+
+        expect(page).to have_no_selector :contentinfo, "Wrong ancestor"
       end
     end
 
     context "when [role=contentinfo]" do
-      context "when direct descendant of body" do
-        it "finds the first element" do
-          render <<~HTML
-            <div role="contentinfo">Content</div>
-          HTML
+      it "finds the first element" do
+        render <<~HTML
+          <div role="contentinfo">Content</div>
+        HTML
 
+        expect(page).to have_selector :contentinfo, count: 1
+      end
+
+      it "finds from self" do
+        render <<~HTML
+          <div role="contentinfo">Content</div>
+        HTML
+
+        within :css, "[role=contentinfo]" do
           expect(page).to have_selector :contentinfo, count: 1
-        end
-
-        it "finds based on [aria-label]" do
-          render <<~HTML
-            <div role="contentinfo" aria-label="Footer contentinfo">Content</div>
-          HTML
-
-          expect(page).to have_selector :contentinfo, "Footer contentinfo"
-        end
-
-        it "does not find differing on [aria-label]" do
-          render <<~HTML
-            <div role="contentinfo" aria-label="Footer contentinfo">Content</div>
-          HTML
-
-          expect(page).to have_no_selector :contentinfo, "Not the right locator"
-        end
-
-        it "finds based on [aria-labelledby]" do
-          render <<~HTML
-            <div role="contentinfo" aria-labelledby="contentinfo_label">
-              <h1 id="contentinfo_label">Footer contentinfo</h1>
-            </div>
-          HTML
-
-          expect(page).to have_selector :contentinfo, "Footer contentinfo"
-        end
-
-        it "does not find differing on [aria-labelledby]" do
-          render <<~HTML
-            <div role="contentinfo" aria-labelledby="contentinfo_label">
-              <h1 id="contentinfo_label">Footer contentinfo</h1>
-            </div>
-          HTML
-
-          expect(page).to have_no_selector :contentinfo, "Not the right locator"
         end
       end
 
-      context "when descendant of another element" do
-        it "does not find any elements" do
-          html = %w[article aside main nav section].map do |element|
-            %(<#{element}><div role="contentinfo">Content</div></#{element}>)
-          end.join
+      it "finds based on [aria-label]" do
+        render <<~HTML
+          <div role="contentinfo" aria-label="Footer contentinfo">Content</div>
+        HTML
 
-          render html
+        expect(page).to have_selector :contentinfo, "Footer contentinfo"
+      end
 
-          expect(page).to have_no_selector :contentinfo
-        end
+      it "does not find differing on [aria-label]" do
+        render <<~HTML
+          <div role="contentinfo" aria-label="Footer contentinfo">Content</div>
+        HTML
 
-        it "does not find based on [aria-label]" do
-          render <<~HTML
-            <section>
-              <div role="contentinfo" aria-label="Footer contentinfo">Content</div>
-            </section>
-          HTML
+        expect(page).to have_no_selector :contentinfo, "Not the right locator"
+      end
 
-          expect(page).to have_no_selector :contentinfo, "Footer contentinfo"
-        end
+      it "finds based on [aria-labelledby]" do
+        render <<~HTML
+          <div role="contentinfo" aria-labelledby="contentinfo_label">
+            <h1 id="contentinfo_label">Footer contentinfo</h1>
+          </div>
+        HTML
 
-        it "does not find based on [aria-labelledby]" do
-          render <<~HTML
-            <section>
-              <div role="contentinfo" aria-labelledby="contentinfo_label">
-                <h1 id="contentinfo_label">Footer contentinfo</h1>
-              </div>
-            </section>
-          HTML
+        expect(page).to have_selector :contentinfo, "Footer contentinfo"
+      end
 
-          expect(page).to have_no_selector :contentinfo, "Footer contentinfo"
-        end
+      it "does not find differing on [aria-labelledby]" do
+        render <<~HTML
+          <div role="contentinfo" aria-labelledby="contentinfo_label">
+            <h1 id="contentinfo_label">Footer contentinfo</h1>
+          </div>
+        HTML
+
+        expect(page).to have_no_selector :contentinfo, "Not the right locator"
+      end
+
+      it "does find if a child of an article" do
+        render <<~HTML
+          <article>
+            <div role="contentinfo">Content</div>
+          </article>
+        HTML
+
+        expect(page).to have_selector :contentinfo
+      end
+
+      it "does find if a child of an aside" do
+        render <<~HTML
+          <aside>
+            <div role="contentinfo">Content</div>
+          </aside>
+        HTML
+
+        expect(page).to have_selector :contentinfo
+      end
+
+      it "does find if a child of a main" do
+        render <<~HTML
+          <main>
+            <div role="contentinfo">Content</div>
+          </main>
+        HTML
+
+        expect(page).to have_selector :contentinfo
+      end
+
+      it "does find if a child of a nav" do
+        render <<~HTML
+          <nav>
+            <div role="contentinfo">Content</div>
+          </nav>
+        HTML
+
+        expect(page).to have_selector :contentinfo
+      end
+
+      it "does find if a child of a section" do
+        render <<~HTML
+          <section>
+            <div role="contentinfo">Content</div>
+          </section>
+        HTML
+
+        expect(page).to have_selector :contentinfo
+      end
+
+      it "does find if a child of an explicit role article" do
+        render <<~HTML
+          <div role="article">
+            <div role="contentinfo">Content</div>
+          </div>
+        HTML
+
+        expect(page).to have_selector :contentinfo
+      end
+
+      it "does find if a child of an explicit role complimentary" do
+        render <<~HTML
+          <div role="complimentary">
+            <div role="contentinfo">Content</div>
+          </div>
+        HTML
+
+        expect(page).to have_selector :contentinfo
+      end
+
+      it "does find if a child of an explicit role main" do
+        render <<~HTML
+          <div role="main">
+            <div role="contentinfo">Content</div>
+          </div>
+        HTML
+
+        expect(page).to have_selector :contentinfo
+      end
+
+      it "does find if a child of an explicit role navigation" do
+        render <<~HTML
+          <div role="navigation">
+            <div role="contentinfo">Content</div>
+          </div>
+        HTML
+
+        expect(page).to have_selector :contentinfo
+      end
+
+      it "does find if a child of an explicit role region" do
+        render <<~HTML
+          <div role="region">
+            <div role="contentinfo">Content</div>
+          </div>
+        HTML
+
+        expect(page).to have_selector :contentinfo
       end
     end
   end

--- a/spec/selectors/main_spec.rb
+++ b/spec/selectors/main_spec.rb
@@ -3,165 +3,113 @@
 describe "main selector" do
   describe "locator" do
     context "when <main> element" do
-      context "when direct descendant of body" do
-        it "finds the first element" do
-          render <<~HTML
-            <main>Content</main>
-          HTML
+      it "finds the first element" do
+        render <<~HTML
+          <main>Content</main>
+        HTML
 
-          expect(page).to have_selector :main, count: 1
-        end
-
-        it "finds based on [aria-label]" do
-          render <<~HTML
-            <main aria-label="Main main">Content</main>
-          HTML
-
-          expect(page).to have_selector :main, "Main main"
-        end
-
-        it "does not find differing on [aria-label]" do
-          render <<~HTML
-            <main aria-label="Main main">Content</main>
-          HTML
-
-          expect(page).to have_no_selector :main, "Not the right locator"
-        end
-
-        it "finds based on [aria-labelledby]" do
-          render <<~HTML
-            <main aria-labelledby="main_label">
-              <h1 id="main_label">Main main</h1>
-            </main>
-          HTML
-
-          expect(page).to have_selector :main, "Main main"
-        end
-
-        it "does not find differing on [aria-labelledby]" do
-          render <<~HTML
-            <main aria-labelledby="main_label">
-              <h1 id="main_label">Main main</h1>
-            </main>
-          HTML
-
-          expect(page).to have_no_selector :main, "Not the right locator"
-        end
+        expect(page).to have_selector :main, count: 1
       end
 
-      context "when descendant of another element" do
-        it "does not find any elements" do
-          html = %w[article aside nav section].map do |element|
-            "<#{element}><main>Content</main></#{element}>"
-          end.join
+      it "finds based on [aria-label]" do
+        render <<~HTML
+          <main aria-label="Main main">Content</main>
+        HTML
 
-          render html
+        expect(page).to have_selector :main, "Main main"
+      end
 
-          expect(page).to have_no_selector :main
-        end
+      it "does not find differing on [aria-label]" do
+        render <<~HTML
+          <main aria-label="Main main">Content</main>
+        HTML
 
-        it "does not find based on [aria-label]" do
-          render <<~HTML
-            <section>
-              <main aria-label="Main main">Content</main>
-            </section>
-          HTML
+        expect(page).to have_no_selector :main, "Not the right locator"
+      end
 
-          expect(page).to have_no_selector :main, "Main main"
-        end
+      it "finds based on [aria-labelledby]" do
+        render <<~HTML
+          <main aria-labelledby="main_label">
+            <h1 id="main_label">Main main</h1>
+          </main>
+        HTML
 
-        it "does not find based on [aria-labelledby]" do
-          render <<~HTML
-            <section>
-              <main aria-labelledby="main_label">
-                <h1 id="main_label">Main main</h1>
-              </main>
-            </section>
-          HTML
+        expect(page).to have_selector :main, "Main main"
+      end
 
-          expect(page).to have_no_selector :main, "Main main"
+      it "does not find differing on [aria-labelledby]" do
+        render <<~HTML
+          <main aria-labelledby="main_label">
+            <h1 id="main_label">Main main</h1>
+          </main>
+        HTML
+
+        expect(page).to have_no_selector :main, "Not the right locator"
+      end
+
+      it "finds from self" do
+        render <<~HTML
+          <main>Content</main>
+        HTML
+
+        within :css, "main" do
+          expect(page).to have_selector :main
         end
       end
     end
 
     context "when [role=main]" do
-      context "when direct descendant of body" do
-        it "finds the first element" do
-          render <<~HTML
-            <div role="main">Content</div>
-          HTML
+      it "finds the first element" do
+        render <<~HTML
+          <div role="main">Content</div>
+        HTML
 
-          expect(page).to have_selector :main, count: 1
-        end
-
-        it "finds based on [aria-label]" do
-          render <<~HTML
-            <div role="main" aria-label="Main main">Content</div>
-          HTML
-
-          expect(page).to have_selector :main, "Main main"
-        end
-
-        it "does not find differing on [aria-label]" do
-          render <<~HTML
-            <div role="main" aria-label="Main main">Content</div>
-          HTML
-
-          expect(page).to have_no_selector :main, "Not the right locator"
-        end
-
-        it "finds based on [aria-labelledby]" do
-          render <<~HTML
-            <div role="main" aria-labelledby="main_label">
-              <h1 id="main_label">Main main</h1>
-            </div>
-          HTML
-
-          expect(page).to have_selector :main, "Main main"
-        end
-
-        it "does not find differing on [aria-labelledby]" do
-          render <<~HTML
-            <div role="main" aria-labelledby="main_label">
-              <h1 id="main_label">Main main</h1>
-            </div>
-          HTML
-
-          expect(page).to have_no_selector :main, "Not the right locator"
-        end
+        expect(page).to have_selector :main, count: 1
       end
 
-      context "when descendant of another element" do
-        it "does not find any elements" do
-          html = %w[article aside nav section].map do |element|
-            %(<#{element}><div role="main">Content</div></#{element}>)
-          end.join
+      it "finds based on [aria-label]" do
+        render <<~HTML
+          <div role="main" aria-label="Main main">Content</div>
+        HTML
 
-          render html
+        expect(page).to have_selector :main, "Main main"
+      end
 
-          expect(page).to have_no_selector :main
-        end
+      it "does not find differing on [aria-label]" do
+        render <<~HTML
+          <div role="main" aria-label="Main main">Content</div>
+        HTML
 
-        it "does not find based on [aria-label]" do
-          render <<~HTML
-            <section>
-              <div role="main" aria-label="Main main">Content</div>
-            </section>
-          HTML
+        expect(page).to have_no_selector :main, "Not the right locator"
+      end
 
-          expect(page).to have_no_selector :main, "Main main"
-        end
+      it "finds based on [aria-labelledby]" do
+        render <<~HTML
+          <div role="main" aria-labelledby="main_label">
+            <h1 id="main_label">Main main</h1>
+          </div>
+        HTML
 
-        it "does not find based on [aria-labelledby]" do
-          render <<~HTML
-            <section>
-              <div role="main" aria-labelledby="main_label">
-                <h1 id="main_label">Main main</h1>
-              </div>
-            </section>
-          HTML
+        expect(page).to have_selector :main, "Main main"
+      end
 
-          expect(page).to have_no_selector :main, "Main main"
+      it "does not find differing on [aria-labelledby]" do
+        render <<~HTML
+          <div role="main" aria-labelledby="main_label">
+            <h1 id="main_label">Main main</h1>
+          </div>
+        HTML
+
+        expect(page).to have_no_selector :main, "Not the right locator"
+      end
+
+      it "finds from self" do
+        render <<~HTML
+          <div role="main">Content</div>
+        HTML
+
+        within :css, "[role=main]" do
+          expect(page).to have_selector :main
         end
       end
     end

--- a/spec/selectors/navigation_spec.rb
+++ b/spec/selectors/navigation_spec.rb
@@ -11,6 +11,16 @@ describe "navigation selector" do
         expect(page).to have_selector :navigation, count: 1
       end
 
+      it "finds from self" do
+        render <<~HTML
+          <nav>Content</nav>
+        HTML
+
+        within :css, "nav" do
+          expect(page).to have_selector :navigation, count: 1
+        end
+      end
+
       it "finds based on [aria-label]" do
         render <<~HTML
           <nav aria-label="Nav navigation">Content</nav>
@@ -55,6 +65,16 @@ describe "navigation selector" do
         HTML
 
         expect(page).to have_selector :navigation, count: 1
+      end
+
+      it "finds from self" do
+        render <<~HTML
+          <div role="navigation">Content</div>
+        HTML
+
+        within :css, "[role=navigation]" do
+          expect(page).to have_selector :navigation, count: 1
+        end
       end
 
       it "finds based on [aria-label]" do


### PR DESCRIPTION
Adjusts the landmark selectors for `:main`, `:banner` and `:contentinfo` not to require their parent to be `<body>`.

The landmark selectors `:banner` and `:contentinfo` are also updated to match the rules in https://w3c.github.io/html-aria/ (which from previous testing are not consistently implemented in browsers, but still seem like good rules to follow).

There should only be one landmark of "main" and it doesn't matter how it is nested.

