### PR TITLE
release 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Extend `Capybara::Node::Simple` with the `role` attribute to support the `:role` filter
+- Extend `Capybara::Node::Simple` with the `role` attribute to support the `:role` filter [Sean Doyle]
 - `:main`, `:banner` and `:contentinfo` selectors no longer requires the element to be a direct child of `<body>`
 - `:banner` and `:contentinfo` selectors use rules from [ARIA in HTML](https://w3c.github.io/html-aria/) for implicit matching
 - `:main`, `:banner`, `:contentinfo`, and `:navigation` are now implemented as `descendant_or_self`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GIT
 PATH
   remote: .
   specs:
-    capybara_accessible_selectors (0.13.0)
+    capybara_accessible_selectors (0.14.0)
       capybara (~> 3.36)
 
 GEM

--- a/lib/capybara_accessible_selectors/version.rb
+++ b/lib/capybara_accessible_selectors/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CapybaraAccessibleSelectors
-  VERSION = "0.13.0"
+  VERSION = "0.14.0"
 end


### PR DESCRIPTION
- Extend `Capybara::Node::Simple` with the `role` attribute to support the `:role` filter [Sean Doyle]
- `:main`, `:banner` and `:contentinfo` selectors no longer requires the element to be a direct child of `<body>`
- `:banner` and `:contentinfo` selectors use rules from [ARIA in HTML](https://w3c.github.io/html-aria/) for implicit matching
- `:main`, `:banner`, `:contentinfo`, and `:navigation` are now implemented as `descendant_or_self`